### PR TITLE
Remove dot from Lesson.ly

### DIFF
--- a/source/includes/_authentication.md
+++ b/source/includes/_authentication.md
@@ -8,11 +8,11 @@ curl -u "DOMAIN:API_KEY" "api_endpoint_here"
 
 ```
 
-> Make sure to replace `DOMAIN` with your Lesson.ly domain and `API_KEY` with your personal API key.
+> Make sure to replace `DOMAIN` with your Lessonly domain and `API_KEY` with your personal API key.
 
-Lesson.ly uses API keys and basic HTTP authorization to allow access to the API. All API requests must be sent over HTTPS. You can register a new Lesson.ly API key by signing into Lesson.ly and navigating to the settings page.  If you do not see the API key link, you may need to request for the feature to be activated:  [here] (mailto:info@lesson.ly).
+Lessonly uses API keys and basic HTTP authorization to allow access to the API. All API requests must be sent over HTTPS. You can register a new Lessonly API key by signing into Lessonly and navigating to the settings page.  If you do not see the API key link, you may need to request for the feature to be activated:  [here] (mailto:info@lessonly.com).
 
 
 <aside class="alert">
-You must replace <code>DOMAIN</code> with your Lesson.ly domain and <code>API_KEY</code> with your personal API key.
+You must replace <code>DOMAIN</code> with your Lessonly domain and <code>API_KEY</code> with your personal API key.
 </aside>

--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -1,6 +1,6 @@
 # Errors
 
-The Lesson.ly API uses the following error codes:
+The Lessonly API uses the following error codes:
 
 Error Code | Meaning
 ---------- | -------

--- a/source/includes/_introduction.md
+++ b/source/includes/_introduction.md
@@ -1,6 +1,6 @@
 
 # Introduction
 
-Welcome to the Lesson.ly API documentation! First you will need to get an API key by signing into your account, navigating to the company settings page and clicking "Show API credentials".
+Welcome to the Lessonly API documentation! First you will need to get an API key by signing into your account, navigating to the company settings page and clicking "Show API credentials".
 
-Currently we only have language bindings for shell, however we are open to providing libraries in other libraries.  Contact us to let us know what libraries you would like to see to connect with Lesson.ly:  [here] (mailto:info@lesson.ly).
+Currently we only have language bindings for shell, however we are open to providing libraries in other libraries.  Contact us to let us know what libraries you would like to see to connect with Lessonly:  [here] (mailto:info@lessonly.com).

--- a/source/includes/_rates.md
+++ b/source/includes/_rates.md
@@ -1,4 +1,4 @@
 
 # Rate Limiting
 
-Lesson.ly currently limits the rate of requests made to the API.  At the limit of 500 requests per minute the API will return "403 Forbidden (Rate Limit Exceeded)".  To avoid hitting this rate limit, you can adjust your scripts and workflows to add pauses in between subsequent API requests.
+Lessonly currently limits the rate of requests made to the API.  At the limit of 500 requests per minute the API will return "403 Forbidden (Rate Limit Exceeded)".  To avoid hitting this rate limit, you can adjust your scripts and workflows to add pauses in between subsequent API requests.


### PR DESCRIPTION
## Why

Lessonly the company no longer has a dot in its name.

## What

This removes the dot from "Lesson.ly" throughout the text in this repo. It does not change "api.lesson.ly" references.