### PR TITLE
We now include overview URLs in lesson/course endpoints

### DIFF
--- a/source/includes/_courses.md.erb
+++ b/source/includes/_courses.md.erb
@@ -59,8 +59,8 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/courses/:course_id
     }
   ],
   "links": {
-    "overview": "http://mycompany.lessonly.com/lessons/48804-course-1",
-    "shareable": "http://mycompany.lessonly.com/lesson/48804-course-1"
+    "overview": "https://mycompany.lessonly.com/lessons/48804-course-1",
+    "shareable": "https://mycompany.lessonly.com/lesson/48804-course-1"
   }
 }
 ```

--- a/source/includes/_courses.md.erb
+++ b/source/includes/_courses.md.erb
@@ -57,7 +57,11 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/courses/:course_id
       "id": 1,
       "title": "Second Lesson"
     }
-  ]
+  ],
+  "links": {
+    "overview": "http://mycompany.lessonly.com/lessons/48804-course-1",
+    "shareable": "http://mycompany.lessonly.com/lesson/48804-course-1"
+  }
 }
 ```
 
@@ -102,7 +106,8 @@ course_id | yes | Positive Integer | The course to access.  The company must hav
       }
     ],
     "links": {
-        "shareable": "https://course-shareable-link"
+      "overview": "https://mycompany.lessonly.com/courses/3934-empty-course",
+      "shareable": "https://mycompany.lessonly.com/course/3934-empty-course"
     },
     "public": false,
     "resource_type": "course",
@@ -158,7 +163,8 @@ course_id | yes | Positive Integer | The course to archive.  The company must ha
       }
     ],
     "links": {
-        "shareable": "https://course-shareable-link"
+      "overview": "https://mycompany.lessonly.com/courses/3934-empty-course",
+      "shareable": "https://mycompany.lessonly.com/course/3934-empty-course"
     },
     "public": false,
     "resource_type": "course",

--- a/source/includes/_lessons.md.erb
+++ b/source/includes/_lessons.md.erb
@@ -57,7 +57,8 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/lessons/:lesson_id
     }
   ],
   "links" : {
-    "shareable": "https://lesson-shareable-link"
+    "overview": "https://mycompany.lessonly.com/lessons/1-lesson-1",
+    "shareable": "https://mycompany.lessonly.com/lesson/1-lesson-1"
   }
 }
 ```
@@ -95,7 +96,8 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/lessons/:lesson_id -d par
     }
   ],
   "links" : {
-    "shareable": "https://lesson-shareable-link"
+    "overview": "https://mycompany.lessonly.com/lessons/1-lesson-1",
+    "shareable": "https://mycompany.lessonly.com/lesson/1-lesson-1"
   }
 }
 ```
@@ -134,7 +136,8 @@ public | no | Boolean | Whether or not the lesson is public
     "id": 43530,
     "last_updated_at": "2016-10-06T16:18:01Z",
     "links": {
-        "shareable": "https://lesson-shareable-link"
+      "overview": "https://mycompany.lessonly.com/lessons/43530-untitled-lesson",
+      "shareable": "https://mycompany.lessonly.com/lesson/43530-untitled-lesson"
     },
     "public": false,
     "resource_type": "lesson",
@@ -181,7 +184,8 @@ lesson_id | yes | Positive Integer | The lesson to archive.  The company must ha
     "id": 43530,
     "last_updated_at": "2016-10-06T16:18:01Z",
     "links": {
-        "shareable": "https://lesson-shareable-link"
+      "overview": "https://mycompany.lessonly.com/lessons/43530-untitled-lesson",
+      "shareable": "https://mycompany.lessonly.com/lesson/43530-untitled-lesson"
     },
     "public": false,
     "resource_type": "lesson",


### PR DESCRIPTION
This also fixes some inconsistent indentation. Our API indents things by 4 spaces, but most of our API docs use 2 (perhaps to save room) so I'm sticking with 2 spaces here.

<img width="1280" alt="screen shot 2016-12-28 at 3 28 38 pm" src="https://cloud.githubusercontent.com/assets/664341/21531019/daf19bc0-cd12-11e6-90f7-53a9d59ebd87.png">

<img width="1262" alt="screen shot 2016-12-28 at 3 32 03 pm" src="https://cloud.githubusercontent.com/assets/664341/21531022/dd8ef148-cd12-11e6-92af-c69452eabed1.png">
