### PR TITLE
Don't suggest /users/:id/assignments returns assignments for multiple users

### DIFF
--- a/source/includes/_users.md.erb
+++ b/source/includes/_users.md.erb
@@ -485,7 +485,7 @@ managing | no | Array | The groups in which the user is managing.  Passing "remo
       "type": "Assignment",
       "resource_type": "assigment",
       "id": 2,
-      "assignee_id": 2,
+      "assignee_id": 1,
       "ext_uid": "DEF456",
       "assignable_id": 2,
       "assignable_type": "Course",


### PR DESCRIPTION
We should have the same `assignee_id` for these.