### PR TITLE
Document company settings update webhook endpoint

### DIFF
--- a/source/includes/_company_settings.md.erb
+++ b/source/includes/_company_settings.md.erb
@@ -1,0 +1,38 @@
+# Company Settings
+
+## Update Webhook URL
+
+```shell
+<%= put_request("/company_settings", params: true) %>
+```
+
+> The following are sample parameters for this request:
+
+```json
+{
+  "lesson_completed_callback_url": "https://webhook.mycompany.com",
+  "lesson_completed_callback_authorization": "Tm93IGlzIHRo"
+}
+```
+
+> A successful update returns a JSON representation of the updated webhook configuration:
+
+```json
+{
+  "lesson_completed_callback_url": "https://webhook.mycompany.com",
+  "lesson_completed_callback_authorization": "Tm93IGlzIHRo"
+}
+```
+
+This endpoint allows you to update the recipient URL for webhooks sent upon Lesson completion. See the docs for [more information on webhooks](http://www.lessonly.com/documentation/reporting-webhook-documentation/).
+
+### HTTP Request
+
+`PUT https://api.lesson.ly/api/v1/company_settings`
+
+### Query Parameters
+
+Parameter                               | Required | Type   | Description
+----------------------------------------|----------|--------|------------
+lesson_completed_callback_url           | no       | String | the URL to which webhooks should be sent
+lesson_completed_callback_authorization | no       | String | the optional value of an `Authorization: VALUE` header to be sent with webhooks

--- a/source/index.md
+++ b/source/index.md
@@ -16,6 +16,7 @@ includes:
   - courses
   - tags
   - assignments
+  - company_settings
   - rates
   - errors
 


### PR DESCRIPTION
Resolves [[ch259]](https://app.clubhouse.io/lessonly/story/259/update-api-docs-for-company-settings-endpoint)

<img width="1263" alt="screen shot 2017-04-27 at 10 16 38 am" src="https://cloud.githubusercontent.com/assets/664341/25487629/cc6534b2-2b32-11e7-96e6-e65ab92debcd.png">

## References

- The PR which introduced this endpoint: https://github.com/lessonly/lessonly/pull/2893

The endpoint in action:

```
$ curl -d "lesson_completed_callback_url=http://webhook.myurl.com&lesson_completed_callback_authorization=secrets" -u "SUBDOMAIN:API_KEY" https://api.lesson.ly/api/v1/company_settings

{"lesson_completed_callback_url":"http://webhook.myurl.com","lesson_completed_callback_authorization":"secrets"}
```

## Post-Merge Task

```
$ cd lessonly-api-docs
$ git pull
$ rake publish
```