### PR TITLE
Change lesson.ly to lessonly.com

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -11,11 +11,11 @@ set :markdown,
 
 helpers do
   def api_get_request(endpoint)
-    "curl -u \"DOMAIN:API_KEY\" \"https://api.lesson.ly/api/v1#{endpoint}\""
+    "curl -u \"DOMAIN:API_KEY\" \"https://api.lessonly.com/api/v1#{endpoint}\""
   end
 
   def post_request(endpoint)
-    "curl -H \"Content-Type: application/json\" -u \"DOMAIN:API_KEY\" -d 'JSON_PARAMS' \"https://api.lesson.ly/api/v1#{endpoint}\""
+    "curl -H \"Content-Type: application/json\" -u \"DOMAIN:API_KEY\" -d 'JSON_PARAMS' \"https://api.lessonly.com/api/v1#{endpoint}\""
   end
 
   def put_request(endpoint, params: false)
@@ -24,7 +24,7 @@ helpers do
     command << '-H "Content-Type: application/json"' if params
     command << '-u "DOMAIN:API_KEY"'
     command << "-d 'JSON_PARAMS'" if params
-    command << "\"https://api.lesson.ly/api/v1#{endpoint}\""
+    command << "\"https://api.lessonly.com/api/v1#{endpoint}\""
     command.join(' ')
   end
 end

--- a/source/includes/_assignments.md.erb
+++ b/source/includes/_assignments.md.erb
@@ -3,7 +3,7 @@
 ## List Assignments
 
 ```shell
-curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/assignments"
+curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/assignments"
 ```
 
 > The above command returns JSON structured like this:
@@ -83,7 +83,7 @@ To view assignments for a particular [user](#user-assignments), [lesson](#lesson
 
 ### HTTP Request
 
-`GET https://api.lesson.ly/api/v1/assignments`
+`GET https://api.lessonly.com/api/v1/assignments`
 
 ### Query Parameters
 
@@ -96,7 +96,7 @@ gt | no | String | Specified greater than filter for assignments list.  Supporte
 ## Show Assignments by Status
 
 ```shell
-curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/assignments/:status"
+curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/assignments/:status"
 ```
 
 > The above command returns JSON structured like this:
@@ -131,7 +131,7 @@ This endpoint retrieves all assignments by their status.
 
 ### HTTP Request
 
-`GET https://api.lesson.ly/api/v1/assignments/:status`
+`GET https://api.lessonly.com/api/v1/assignments/:status`
 
 ### Query Parameters
 

--- a/source/includes/_company_settings.md.erb
+++ b/source/includes/_company_settings.md.erb
@@ -28,7 +28,7 @@ This endpoint allows you to update the recipient URL for webhooks sent upon Less
 
 ### HTTP Request
 
-`PUT https://api.lesson.ly/api/v1/company_settings`
+`PUT https://api.lessonly.com/api/v1/company_settings`
 
 ### Query Parameters
 

--- a/source/includes/_courses.md.erb
+++ b/source/includes/_courses.md.erb
@@ -3,7 +3,7 @@
 ## List Courses
 
 ```shell
-curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/courses"
+curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/courses"
 ```
 
 > The above command returns JSON structured like this:
@@ -28,12 +28,12 @@ This endpoint retrieves all courses.
 
 ### HTTP Request
 
-`GET https://api.lesson.ly/api/v1/courses`
+`GET https://api.lessonly.com/api/v1/courses`
 
 ## Show Course Details
 
 ```shell
-curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/courses/:course_id
+curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/courses/:course_id
 ```
 
 > The above command returns JSON structured like this:
@@ -80,7 +80,7 @@ This endpoint retrieves all the courses details including their lessons and some
 
 ### HTTP Request
 
-`GET https://api.lesson.ly/api/v1/courses/:course_id`
+`GET https://api.lessonly.com/api/v1/courses/:course_id`
 
 ### Query Parameters
 
@@ -137,7 +137,7 @@ This endpoint allows the archiving of a single course.
 
 ### HTTP Request
 
-`PUT https://api.lesson.ly/api/v1/courses/:course_id/archive`
+`PUT https://api.lessonly.com/api/v1/courses/:course_id/archive`
 
 ### Query Parameters
 
@@ -194,7 +194,7 @@ This endpoint allows the restoring of a single archived course.
 
 ### HTTP Request
 
-`PUT https://api.lesson.ly/api/v1/courses/:course_id/restore`
+`PUT https://api.lessonly.com/api/v1/courses/:course_id/restore`
 
 ### Query Parameters
 
@@ -205,7 +205,7 @@ course_id | yes | Positive Integer | The course to restore.  The company must ha
 ## Course Assignments
 
 ```shell
-curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/courses/:course_id/assignments
+curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/courses/:course_id/assignments
 ```
 
 > The above command returns JSON structured like this:
@@ -255,7 +255,7 @@ This endpoint retrieves all the assignments for a particular course.
 
 ### HTTP Request
 
-`GET https://api.lesson.ly/api/v1/courses/:course_id/assignments`
+`GET https://api.lessonly.com/api/v1/courses/:course_id/assignments`
 
 ### Query Parameters
 
@@ -313,11 +313,11 @@ This endpoint allows you to make assignments to a particular course in the API.
 
 ### HTTP Request
 
-`PUT https://api.lesson.ly/api/v1/courses/:course_id/assignments -d params`
+`PUT https://api.lessonly.com/api/v1/courses/:course_id/assignments -d params`
 
 ### Query Parameters
 
 Parameter | Required | Type |  Description
 --- | --- | --- | ---
 course_id | yes | Positive Integer | The course to access. The company must have access to the user.
-assignments | no | Hash | A hash of assignments to be made to the course.  If the assignment for a particular user already exists, the user will be reassigned the course. By default, an email will be sent to the assignee; it will come from notifications@lesson.ly. To suppress the email notification set `notify` to `false`.
+assignments | no | Hash | A hash of assignments to be made to the course.  If the assignment for a particular user already exists, the user will be reassigned the course. By default, an email will be sent to the assignee; it will come from notifications@lessonly.com. To suppress the email notification set `notify` to `false`.

--- a/source/includes/_groups.md.erb
+++ b/source/includes/_groups.md.erb
@@ -3,7 +3,7 @@
 ## List Groups
 
 ```shell
-curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/groups"
+curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/groups"
 ```
 
 > The above command returns JSON structured like this:
@@ -22,12 +22,12 @@ This endpoint retrieves all groups.
 
 ### HTTP Request
 
-`GET https://api.lesson.ly/api/v1/groups`
+`GET https://api.lessonly.com/api/v1/groups`
 
 ## Show Group Details
 
 ```shell
-curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/groups/:group_id"
+curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/groups/:group_id"
 ```
 
 > The above command returns JSON structured like this:
@@ -60,7 +60,7 @@ group_id | yes | Positive Integer | The group to access.  The company must have 
 
 ### HTTP Request
 
-`GET https://api.lesson.ly/api/v1/groups/:group_id`
+`GET https://api.lessonly.com/api/v1/groups/:group_id`
 
 ## Create Group
 
@@ -110,7 +110,7 @@ This endpoint allows you to create a group and its members and managers.
 
 ### HTTP Request
 
-`POST https://api.lesson.ly/api/v1/groups/ -d params`
+`POST https://api.lessonly.com/api/v1/groups/ -d params`
 
 ### Query Parameters
 
@@ -167,7 +167,7 @@ This endpoint allows you to update a group and its members and managers.
 
 ### HTTP Request
 
-`PUT https://api.lesson.ly/api/v1/groups/:group_id/ -d params`
+`PUT https://api.lessonly.com/api/v1/groups/:group_id/ -d params`
 
 ### Query Parameters
 
@@ -207,7 +207,7 @@ This endpoint allows the archiving of a single group.
 
 ### HTTP Request
 
-`PUT https://api.lesson.ly/api/v1/groups/:group_id/archive`
+`PUT https://api.lessonly.com/api/v1/groups/:group_id/archive`
 
 ### Query Parameters
 
@@ -244,7 +244,7 @@ This endpoint allows the restoring of a single archived group.
 
 ### HTTP Request
 
-`PUT https://api.lesson.ly/api/v1/groups/:group_id/restore`
+`PUT https://api.lessonly.com/api/v1/groups/:group_id/restore`
 
 ### Query Parameters
 
@@ -281,7 +281,7 @@ This endpoint returns a list of all lessons and courses that have been assigned 
 
 ### HTTP Request
 
-`GET https://api.lesson.ly/api/v1/groups/:group_id/assignments`
+`GET https://api.lessonly.com/api/v1/groups/:group_id/assignments`
 
 ### Query Parameters
 

--- a/source/includes/_lessons.md.erb
+++ b/source/includes/_lessons.md.erb
@@ -3,7 +3,7 @@
 ## List Lessons
 
 ```shell
-curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/lessons"
+curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/lessons"
 ```
 
 > The above command returns JSON structured like this:
@@ -28,12 +28,12 @@ This endpoint retrieves all lessons.
 
 ### HTTP Request
 
-`GET https://api.lesson.ly/api/v1/lessons`
+`GET https://api.lessonly.com/api/v1/lessons`
 
 ## Show Lesson Details
 
 ```shell
-curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/lessons/:lesson_id
+curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/lessons/:lesson_id
 ```
 
 > The above command returns JSON structured like this:
@@ -69,13 +69,13 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/lessons/:lesson_id
 This endpoint retrieves all the lesson details including statistics about the completion of the lesson.
 ### HTTP Request
 
-`GET https://api.lesson.ly/api/v1/lessons/:lesson_id`
+`GET https://api.lessonly.com/api/v1/lessons/:lesson_id`
 
 
 ## Update Lesson
 
 ```shell
-curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/lessons/:lesson_id -d params
+curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/lessons/:lesson_id -d params
 ```
 
 > The above command returns JSON structured like this:
@@ -109,7 +109,7 @@ This endpoint allows the updating of a single lesson and its attributes.
 
 ### HTTP Request
 
-`PUT https://api.lesson.ly/api/v1/lessons/:lesson_id -d params`
+`PUT https://api.lessonly.com/api/v1/lessons/:lesson_id -d params`
 
 ### Query Parameters
 
@@ -160,7 +160,7 @@ This endpoint allows the archiving of a single lesson.
 
 ### HTTP Request
 
-`PUT https://api.lesson.ly/api/v1/lessons/:lesson_id/archive`
+`PUT https://api.lessonly.com/api/v1/lessons/:lesson_id/archive`
 
 ### Query Parameters
 
@@ -208,7 +208,7 @@ This endpoint allows the restoring of a single archived lesson.
 
 ### HTTP Request
 
-`PUT https://api.lesson.ly/api/v1/lessons/:lesson_id/restore`
+`PUT https://api.lessonly.com/api/v1/lessons/:lesson_id/restore`
 
 ### Query Parameters
 
@@ -219,7 +219,7 @@ lesson_id | yes | Positive Integer | The lesson to restore.  The company must ha
 ## Lesson Assignments
 
 ```shell
-curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/lessons/:lesson_id/assignments
+curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/lessons/:lesson_id/assignments
 ```
 
 > The above command returns JSON structured like this:
@@ -264,7 +264,7 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/lessons/:lesson_id/assign
 This endpoint retrieves all the assignments for a particular lesson.
 ### HTTP Request
 
-`GET https://api.lesson.ly/api/v1/lessons/:lesson_id/assignments`
+`GET https://api.lessonly.com/api/v1/lessons/:lesson_id/assignments`
 
 ### Query Parameters
 
@@ -323,11 +323,11 @@ This endpoint allows you to make assignments to a particular lesson in the API.
 
 ### HTTP Request
 
-`PUT https://api.lesson.ly/api/v1/lessons/:lesson_id/assignments -d params`
+`PUT https://api.lessonly.com/api/v1/lessons/:lesson_id/assignments -d params`
 
 ### Query Parameters
 
 Parameter | Required | Type |  Description
 --- | --- | --- | ---
 lesson_id | yes | Positive Integer | The lesson to access.  The company must have access to the user.
-assignments | no | Hash | A hash of assignments to be made to the lesson.  If the assignment for a particular user already exists, the user will be reassigned the lesson. By default, an email will be sent to the assignee; it will come from notifications@lesson.ly. To suppress the email notification set `notify` to `false`.
+assignments | no | Hash | A hash of assignments to be made to the lesson.  If the assignment for a particular user already exists, the user will be reassigned the lesson. By default, an email will be sent to the assignee; it will come from notifications@lessonly.com. To suppress the email notification set `notify` to `false`.

--- a/source/includes/_tags.md
+++ b/source/includes/_tags.md
@@ -3,7 +3,7 @@
 ## List Tags
 
 ```shell
-curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/tags"
+curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/tags"
 ```
 
 > The above command returns JSON structured like this:
@@ -30,12 +30,12 @@ This endpoint retrieves all tags.
 
 ### HTTP Request
 
-`GET https://api.lesson.ly/api/v1/tags`
+`GET https://api.lessonly.com/api/v1/tags`
 
 ## Show Tag Details
 
 ```shell
-curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/tags/:tag_id
+curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/tags/:tag_id
 ```
 
 > The above command returns JSON structured like this:
@@ -52,7 +52,7 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/tags/:tag_id
 This endpoint retrieves all the tag details.
 ### HTTP Request
 
-`GET https://api.lesson.ly/api/v1/tags/:tag_id`
+`GET https://api.lessonly.com/api/v1/tags/:tag_id`
 
 ### Query Parameters
 
@@ -63,7 +63,7 @@ tag_id | yes | Positive Integer | The tag to access.  The company must have acce
 ## Tag Lessons
 
 ```shell
-curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/tags/:tag_id/lessons
+curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/tags/:tag_id/lessons
 ```
 
 > The above command returns JSON structured like this:
@@ -97,7 +97,7 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/tags/:tag_id/lessons
 This endpoint retrieves all the lessons tagged with a particular tag.
 ### HTTP Request
 
-`GET https://api.lesson.ly/api/v1/tags/:tag_id/lessons`
+`GET https://api.lessonly.com/api/v1/tags/:tag_id/lessons`
 
 ### Query Parameters
 
@@ -108,7 +108,7 @@ tag_id | yes | Positive Integer | The tag to access.  The company must have acce
 ## Tag Courses
 
 ```shell
-curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/tags/:tag_id/courses
+curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/tags/:tag_id/courses
 ```
 
 > The above command returns JSON structured like this:
@@ -152,7 +152,7 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/tags/:tag_id/courses
 This endpoint retrieves all the courses tagged with a particular tag.
 ### HTTP Request
 
-`GET https://api.lesson.ly/api/v1/tags/:tag_id/courses`
+`GET https://api.lessonly.com/api/v1/tags/:tag_id/courses`
 
 ### Query Parameters
 

--- a/source/includes/_users.md.erb
+++ b/source/includes/_users.md.erb
@@ -39,7 +39,7 @@ This endpoint retrieves all users.
 
 ### HTTP Request
 
-`GET https://api.lesson.ly/api/v1/users?filter[email]=email@example.com`
+`GET https://api.lessonly.com/api/v1/users?filter[email]=email@example.com`
 
 ### Query Parameters
 
@@ -82,7 +82,7 @@ This endpoint retrieves all the user's details including their custom field data
 
 ### HTTP Request
 
-`GET https://api.lesson.ly/api/v1/users/:user_id`
+`GET https://api.lessonly.com/api/v1/users/:user_id`
 
 ### Query Parameters
 
@@ -114,7 +114,7 @@ This endpoint retrieves all the user's learning library statistics.
 
 ### HTTP Request
 
-`GET https://api.lesson.ly/api/v1/users/:user_id/learning_library_statistics`
+`GET https://api.lessonly.com/api/v1/users/:user_id/learning_library_statistics`
 
 ### Query Parameters
 
@@ -180,7 +180,7 @@ This endpoint allows you to create a user in the api.
 
 ### HTTP Request
 
-`POST https://api.lesson.ly/api/v1/users/ -d params`
+`POST https://api.lessonly.com/api/v1/users/ -d params`
 
 ### Query Parameters
 
@@ -251,7 +251,7 @@ This endpoint allows you to update a user in the api.
 
 ### HTTP Request
 
-`PUT https://api.lesson.ly/api/v1/users/:user_id -d params`
+`PUT https://api.lessonly.com/api/v1/users/:user_id -d params`
 
 ### Query Parameters
 
@@ -292,7 +292,7 @@ This endpoint allows the archiving of a single user.
 
 ### HTTP Request
 
-`PUT https://api.lesson.ly/api/v1/users/:user_id/archive`
+`PUT https://api.lessonly.com/api/v1/users/:user_id/archive`
 
 ### Query Parameters
 
@@ -327,7 +327,7 @@ This endpoint allows the restoring of a single archived user.
 
 ### HTTP Request
 
-`PUT https://api.lesson.ly/api/v1/users/:user_id/restore`
+`PUT https://api.lessonly.com/api/v1/users/:user_id/restore`
 
 ### Query Parameters
 
@@ -338,7 +338,7 @@ user_id | yes | Positive Integer | The user to restore.  The company must have a
 ## Delete User
 
 ```shell
-curl -X DELETE -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/users/:user_id"
+curl -X DELETE -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/users/:user_id"
 ```
 
 > A successful update returns JSON consisting of the id of the deleted user
@@ -354,7 +354,7 @@ This endpoint allows you to delete a user in the API.
 
 ### HTTP Request
 
-`DELETE https://api.lesson.ly/api/v1/users/:user_id`
+`DELETE https://api.lessonly.com/api/v1/users/:user_id`
 
 ### Query Parameters
 
@@ -390,7 +390,7 @@ This endpoint allows you to list out a user's group memberships and groups they 
 
 ### HTTP Request
 
-`GET https://api.lesson.ly/api/v1/users/:user_id/groups`
+`GET https://api.lessonly.com/api/v1/users/:user_id/groups`
 
 ### Query Parameters
 
@@ -444,7 +444,7 @@ This endpoint allows you to update a user's involvement in various groups.
 
 ### HTTP Request
 
-`PUT https://api.lesson.ly/api/v1/users/:user_id/groups`
+`PUT https://api.lessonly.com/api/v1/users/:user_id/groups`
 
 ### Query Parameters
 
@@ -505,7 +505,7 @@ This endpoint returns a list of assignments for a given user.
 
 ### HTTP Request
 
-`GET https://api.lesson.ly/api/v1/users/:user_id/assignments`
+`GET https://api.lessonly.com/api/v1/users/:user_id/assignments`
 
 ### Query Parameters
 
@@ -585,11 +585,11 @@ This endpoint allows you to create assignments for a user.
 
 ### HTTP Request
 
-`POST https://api.lesson.ly/api/v1/users/:user_id/assignments`
+`POST https://api.lessonly.com/api/v1/users/:user_id/assignments`
 
 ### Query Parameters
 
 Parameter | Required | Type |  Description
 --- | --- | --- | ---
 user_id | yes | Positive Integer | The user to access.  The company must have access to the user.
-assignments | yes | Array |  Array of assignments to be made to the user.  Each requires an assignable_id and assignable_type of "Lesson" or "Course". By default, an email will be sent to the assignee; it will come from notifications@lesson.ly. To suppress the email notification set `notify` to `false`.
+assignments | yes | Array |  Array of assignments to be made to the user.  Each requires an assignable_id and assignable_type of "Lesson" or "Course". By default, an email will be sent to the assignee; it will come from notifications@lessonly.com. To suppress the email notification set `notify` to `false`.


### PR DESCRIPTION
## Why?

Resolves [[ch3038]](https://app.clubhouse.io/lessonly/story/3038)

The API docs still reference `lesson.ly`.

## What?

This PR updates the documentation to reference `lessonly.com`.

## Deploying

This will need to be merged into master and then run `rake publish` run to deploy it. Feel free to ping me if you don't have the app locally to deploy easily.
