### PR TITLE
Add Paths API endpoint documentation

### DIFF
--- a/source/includes/_assignments.md.erb
+++ b/source/includes/_assignments.md.erb
@@ -35,7 +35,7 @@ curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/assignments"
       "id": 2,
       "resource_type": "assignment",
       "assignee_id": 2,
-      "assignable_type": "Course",
+      "assignable_type": "Path",
       "assignable_id": 1,
       "ext_uid": "DEF456",
       "due_by": "2020-09-30T00:00:00Z",
@@ -49,7 +49,7 @@ curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/assignments"
       "id": 3,
       "resource_type": "assignment",
       "assignee_id": 3,
-      "assignable_type": "Course",
+      "assignable_type": "Path",
       "assignable_id": 1,
       "ext_uid": "DEF456",
       "due_by": "2016-03-27T14:15:17Z",
@@ -63,7 +63,7 @@ curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/assignments"
       "id": 4,
       "resource_type": "assignment",
       "assignee_id": 4,
-      "assignable_type": "Course",
+      "assignable_type": "Path",
       "assignable_id": 1,
       "ext_uid": "DEF456",
       "due_by": "2020-09-30T00:00:00Z",
@@ -77,9 +77,9 @@ curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/assignments"
 }
 ```
 
-This endpoint returns paginated assignments in no particular order across all of your users, lessons, and courses. Optionally, you can filter by assignments with activity after a given ISO8601 timestamp by passing `gt[updated_at]=TIMESTAMP` in the query string.
+This endpoint returns paginated assignments in no particular order across all of your users, lessons, and paths. Optionally, you can filter by assignments with activity after a given ISO8601 timestamp by passing `gt[updated_at]=TIMESTAMP` in the query string.
 
-To view assignments for a particular [user](#user-assignments), [lesson](#lesson-assignments), or [course](#course-assignments) please use those dedicated endpoints.
+To view assignments for a particular [user](#user-assignments), [lesson](#lesson-assignments), or [path](#path-assignments) please use those dedicated endpoints.
 
 ### HTTP Request
 
@@ -112,7 +112,7 @@ curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/assignments/:status"
       "id": 2,
       "resource_type": "assignment",
       "assignee_id": 2,
-      "assignable_type": "Course",
+      "assignable_type": "Path",
       "assignable_id": 1,
       "ext_uid": "DEF456",
       "due_by": "2020-09-30T00:00:00Z",

--- a/source/includes/_groups.md.erb
+++ b/source/includes/_groups.md.erb
@@ -311,13 +311,13 @@ group_id | yes | Positive Integer | The group to delete.  The company must have 
   {
     "id": 2,
     "assignable_id": 15,
-    "assignable_type": "Course",
+    "assignable_type": "Path",
     "group_id": 5
   }
 ]
 ```
 
-This endpoint returns a list of all lessons and courses that have been assigned to the given group, in no particular order. Results include both archived and unarchived learning content.
+This endpoint returns a list of all lessons and paths that have been assigned to the given group, in no particular order. Results include both archived and unarchived learning content.
 
 ### HTTP Request
 

--- a/source/includes/_paths.md.erb
+++ b/source/includes/_paths.md.erb
@@ -1,0 +1,436 @@
+# Paths
+
+## List Paths
+
+```shell
+curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/paths"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "type": "paths",
+  "paths": [
+    {
+      "id": 1,
+      "title": "Path 1",
+      "archived_at": null,
+      "archived_by_user_id": null
+    },
+    {
+      "id": 2,
+      "title": "Path 2",
+      "archived_at": "2017-06-28T10:46:03.467-04:00",
+      "archived_by_user_id": 123
+    }
+  ]
+}
+```
+
+This endpoint retrieves all paths.
+
+### HTTP Request
+
+`GET https://api.lessonly.com/api/v1/paths`
+
+## Show Path Details
+
+```shell
+curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/paths/:path_id"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "type": "path",
+  "id": 1,
+  "resource_type": "path",
+  "title": "Developer Onboarding",
+  "description": "All you need to know to get up-and-running.",
+  "enforced_order": true,
+  "public": false,
+  "created_at": "2017-07-24T10:47:23Z",
+  "last_updated_at": "2017-07-24T10:49:10Z",
+  "published_at": null,
+  "publisher_id": null,
+  "tags": [
+    {
+      "id": 1,
+      "resource_type": "tag",
+      "name": "Engineering"
+    }
+  ],
+  "links": {
+    "shareable": "https://mycompany.lessonly.com/path/1-developer-onboarding",
+    "overview": "https://mycompany.lessonly.com/paths/1-developer-onboarding"
+  },
+  "archived_at": null,
+  "archived_by_user_id": null,
+  "contents": [
+    {
+      "id": 10,
+      "resource_type": "lesson",
+      "title": "Setting up a development environment",
+      "archived_at": null,
+      "archived_by_user_id": null
+    },
+    {
+      "id": 2,
+      "resource_type": "wait_step",
+      "effect": "locked",
+      "condition": "prev_step_finished",
+      "unit": "days",
+      "amount": 3
+    },
+    {
+      "id": 20,
+      "resource_type": "path",
+      "title": "Know Your Tools",
+      "archived_at": null,
+      "archived_by_user_id": null,
+      "contents": [
+        {
+          "id": 4,
+          "type": "lesson",
+          "title": "Clubhouse 101",
+          "archived_at": null,
+          "archived_by_user_id": null
+        },
+        {
+          "id": 5,
+          "resource_type": "placeholder",
+          "description": "Add a lesson about Github"
+        }
+      ]
+    }
+  ]
+}
+```
+
+This endpoint retrieves all the paths details including their steps.
+
+### HTTP Request
+
+`GET https://api.lessonly.com/api/v1/paths/:path_id`
+
+### Query Parameters
+
+Parameter | Required | Type |  Description
+--- | --- | --- | ---
+path_id | yes | Positive Integer | The path to access. The company must have access to the path.
+
+## Archive Path
+
+```shell
+curl -X PUT -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/paths/:path_id/archive"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "type": "path",
+  "id": 1,
+  "resource_type": "path",
+  "title": "Developer Onboarding",
+  "description": "All you need to know to get up-and-running.",
+  "enforced_order": true,
+  "public": false,
+  "created_at": "2017-07-24T10:47:23Z",
+  "last_updated_at": "2017-07-24T10:49:10Z",
+  "published_at": null,
+  "publisher_id": null,
+  "tags": [
+    {
+      "id": 1,
+      "resource_type": "tag",
+      "name": "Engineering"
+    }
+  ],
+  "links": {
+    "shareable": "https://mycompany.lessonly.com/path/1-developer-onboarding",
+    "overview": "https://mycompany.lessonly.com/paths/1-developer-onboarding"
+  },
+  "archived_at": "2016-10-13T09:51:13.549-04:00",
+  "archived_by_user_id": 1,
+  "contents": [
+    {
+      "id": 10,
+      "resource_type": "lesson",
+      "title": "Setting up a development environment",
+      "archived_at": null,
+      "archived_by_user_id": null
+    },
+    {
+      "id": 2,
+      "resource_type": "wait_step",
+      "effect": "locked",
+      "condition": "prev_step_finished",
+      "unit": "days",
+      "amount": 3
+    },
+    {
+      "id": 20,
+      "resource_type": "path",
+      "title": "Know Your Tools",
+      "archived_at": null,
+      "archived_by_user_id": null,
+      "contents": [
+        {
+          "id": 4,
+          "type": "lesson",
+          "title": "Clubhouse 101",
+          "archived_at": null,
+          "archived_by_user_id": null
+        },
+        {
+          "id": 5,
+          "resource_type": "placeholder",
+          "description": "Add a lesson about Github"
+        }
+      ]
+    }
+  ]
+}
+```
+
+This endpoint allows the archiving of a single path.
+
+### HTTP Request
+
+`PUT https://api.lessonly.com/api/v1/paths/:path_id/archive`
+
+### Query Parameters
+
+Parameter | Required | Type |  Description
+--- | --- | --- | ---
+path_id | yes | Positive Integer | The path to archive. The company must have access to the path.
+
+## Restore Path
+
+```shell
+curl -X PUT -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/paths/:path_id/restore"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "type": "path",
+  "id": 1,
+  "resource_type": "path",
+  "title": "Developer Onboarding",
+  "description": "All you need to know to get up-and-running.",
+  "enforced_order": true,
+  "public": false,
+  "created_at": "2017-07-24T10:47:23Z",
+  "last_updated_at": "2017-07-24T10:49:10Z",
+  "published_at": null,
+  "publisher_id": null,
+  "tags": [
+    {
+      "id": 1,
+      "resource_type": "tag",
+      "name": "Engineering"
+    }
+  ],
+  "links": {
+    "shareable": "https://mycompany.lessonly.com/path/1-developer-onboarding",
+    "overview": "https://mycompany.lessonly.com/paths/1-developer-onboarding"
+  },
+  "archived_at": null,
+  "archived_by_user_id": null,
+  "contents": [
+    {
+      "id": 10,
+      "resource_type": "lesson",
+      "title": "Setting up a development environment",
+      "archived_at": null,
+      "archived_by_user_id": null
+    },
+    {
+      "id": 2,
+      "resource_type": "wait_step",
+      "effect": "locked",
+      "condition": "prev_step_finished",
+      "unit": "days",
+      "amount": 3
+    },
+    {
+      "id": 20,
+      "resource_type": "path",
+      "title": "Know Your Tools",
+      "archived_at": null,
+      "archived_by_user_id": null,
+      "contents": [
+        {
+          "id": 4,
+          "type": "lesson",
+          "title": "Clubhouse 101",
+          "archived_at": null,
+          "archived_by_user_id": null
+        },
+        {
+          "id": 5,
+          "resource_type": "placeholder",
+          "description": "Add a lesson about Github"
+        }
+      ]
+    }
+  ]
+}
+```
+
+This endpoint allows the restoring of a single archived path.
+
+### HTTP Request
+
+`PUT https://api.lessonly.com/api/v1/paths/:path_id/restore`
+
+### Query Parameters
+
+Parameter | Required | Type |  Description
+--- | --- | --- | ---
+path_id | yes | Positive Integer | The path to restore.  The company must have access to the path.
+
+## Assign Path
+
+```shell
+curl -X PUT -H "Content-Type: application/json" -u "DOMAIN:API_KEY" -d 'JSON_PARAMS' "https://api.lessonly.com/api/v1/paths/:path_id/assignments"
+
+```
+
+> The following are sample parameters for this request:
+
+```json
+{
+  "assignments":[
+    {
+      "assignee_id": 1,
+      "due_by": "2020-09-30T00:00:00Z",
+      "notify": false
+    }
+  ]
+}
+```
+
+> A successful update returns a JSON formatted version of the assignments made
+
+```json
+{
+  "type": "update_path_assignments",
+  "assignments": [
+    {
+      "id": 1,
+      "resource_type": "assignment",
+      "assignee_id": 1,
+      "assignable_type": "LearningPaths::Path",
+      "assignable_id": 1,
+      "ext_uid": "ABC123",
+      "due_by": "2020-09-30T00:00:00Z",
+      "reassigned_at": "2020-09-30T00:00:00Z",
+      "completed_at": "2020-09-30T00:00:00Z",
+      "status": "Incomplete",
+      "score": null
+    }
+  ]
+}
+```
+
+This endpoint allows you to make assignments to a particular path in the API.
+
+### HTTP Request
+
+`PUT https://api.lessonly.com/api/v1/paths/:path_id/assignments -d params`
+
+### Query Parameters
+
+Parameter | Required | Type |  Description
+--- | --- | --- | ---
+path_id | yes | Positive Integer | The path to access. The company must have access to the user.
+assignments | no | Hash | A hash of assignments to be made to the path.  If the assignment for a particular user already exists, the user will be reassigned the path. By default, an email will be sent to the assignee; it will come from notifications@lessonly.com. To suppress the email notification set `notify` to `false`.
+
+## List Path Assignments
+
+```shell
+curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/paths/:path_id/assignments
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "type": "path_assignments",
+  "total_assignments": 2,
+  "page": 1,
+  "per_page": 10,
+  "total_pages": 1,
+  "assignments":[
+    {
+      "id": 1,
+      "resource_type": "assignment",
+      "assignee_id": 2,
+      "assignable_type": "LearningPaths::Path",
+      "assignable_id": 1,
+      "ext_uid": "ABC123",
+      "due_by": "2020-09-30T00:00:00Z",
+      "assigned_at": "2020-03-20T00:00:00Z",
+      "reassigned_at": "2020-09-30T00:00:00Z",
+      "status": "Completed",
+      "started_at": "2016-03-28T14:15:17Z",
+      "completed_at": "2016-03-28T18:20:06Z",
+      "updated_at": "2016-03-28T18:20:06Z"
+    },
+    {
+      "id": 2,
+      "resource_type": "assignment",
+      "assignee_id": 3,
+      "assignable_type": "LearningPaths::Path",
+      "assignable_id": 1,
+      "ext_uid": "DEF456",
+      "due_by": "2020-09-30T00:00:00Z",
+      "reassigned_at": "2020-09-30T00:00:00Z",
+      "status": "Incomplete",
+      "started_at": "2016-03-28T14:15:17Z",
+      "completed_at": null,
+      "updated_at": "2016-03-28T18:20:06Z"
+    }
+  ]
+}
+```
+
+This endpoint retrieves all the assignments for a particular path.
+
+### HTTP Request
+
+`GET https://api.lessonly.com/api/v1/paths/:path_id/assignments`
+
+### Query Parameters
+
+Parameter | Required | Type |  Description
+--- | --- | --- | ---
+path_id | yes | Positive Integer | The path to access.  The company must have access to the lesson.
+<%= pagination_query_params.chomp %>
+
+## Path Assignments Completed
+
+```shell
+curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/paths/:path_id/assignments/completed
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "type": "path_assignments_completed",
+  "completed_count": 11
+}
+```
+
+This endpoint retrieves the count of completed assignments for a particular path.
+
+### HTTP Request
+
+`GET https://api.lessonly.com/api/v1/paths/1/assignments/completed`

--- a/source/includes/_paths.md.erb
+++ b/source/includes/_paths.md.erb
@@ -109,7 +109,7 @@ curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/paths/:path_id"
 }
 ```
 
-This endpoint retrieves all the paths details including their steps.
+This endpoint retrieves all the path's details including their steps.
 
 ### HTTP Request
 
@@ -295,7 +295,7 @@ Parameter | Required | Type |  Description
 --- | --- | --- | ---
 path_id | yes | Positive Integer | The path to restore.  The company must have access to the path.
 
-## Assign Path
+## Assigning a Path
 
 ```shell
 curl -X PUT -H "Content-Type: application/json" -u "DOMAIN:API_KEY" -d 'JSON_PARAMS' "https://api.lessonly.com/api/v1/paths/:path_id/assignments"
@@ -316,7 +316,7 @@ curl -X PUT -H "Content-Type: application/json" -u "DOMAIN:API_KEY" -d 'JSON_PAR
 }
 ```
 
-> A successful update returns a JSON formatted version of the assignments made
+> A successful update returns a JSON formatted version of the assignments made:
 
 ```json
 {
@@ -349,7 +349,7 @@ This endpoint allows you to make assignments to a particular path in the API.
 
 Parameter | Required | Type |  Description
 --- | --- | --- | ---
-path_id | yes | Positive Integer | The path to access. The company must have access to the user.
+path_id | yes | Positive Integer | The path to access. The company must have access to the path.
 assignments | no | Hash | A hash of assignments to be made to the path.  If the assignment for a particular user already exists, the user will be reassigned the path. By default, an email will be sent to the assignee; it will come from notifications@lessonly.com. To suppress the email notification set `notify` to `false`.
 
 ## List Path Assignments
@@ -411,7 +411,7 @@ This endpoint retrieves all the assignments for a particular path.
 
 Parameter | Required | Type |  Description
 --- | --- | --- | ---
-path_id | yes | Positive Integer | The path to access.  The company must have access to the lesson.
+path_id | yes | Positive Integer | The path to access.  The company must have access to the path.
 <%= pagination_query_params.chomp %>
 
 ## Path Assignments Completed
@@ -433,4 +433,10 @@ This endpoint retrieves the count of completed assignments for a particular path
 
 ### HTTP Request
 
-`GET https://api.lessonly.com/api/v1/paths/1/assignments/completed`
+`GET https://api.lessonly.com/api/v1/paths/:path_id/assignments/completed`
+
+### Query Parameters
+
+ Parameter | Required | Type |  Description
+ --- | --- | --- | ---
+ path_id | yes | Positive Integer | The path to access.  The company must have access to the path.

--- a/source/includes/_users.md.erb
+++ b/source/includes/_users.md.erb
@@ -562,7 +562,7 @@ managing | no | Array | The groups in which the user is managing.  Passing "remo
       "assignee_id": 1,
       "ext_uid": "DEF456",
       "assignable_id": 2,
-      "assignable_type": "Course",
+      "assignable_type": "Path",
       "due_by": "2020-09-30T00:00:00Z",
       "reassigned_at": "2020-09-30T00:00:00Z",
       "completed_at": null,
@@ -607,7 +607,7 @@ user_id | yes | Positive Integer | The user to access.  The company must have ac
       }
       {
         "assignable_id": 3,
-        "assignable_type": "Course",
+        "assignable_type": "Path",
         "due_by": "2020-09-30",
         "notify": false
       }
@@ -642,7 +642,7 @@ user_id | yes | Positive Integer | The user to access.  The company must have ac
       "assignee_id": 2,
       "ext_uid": "DEF456",
       "assignable_id": 2,
-      "assignable_type": "Course",
+      "assignable_type": "Path",
       "due_by": "2020-09-30T00:00:00Z",
       "reassigned_at": "2020-09-30T00:00:00Z",
       "completed_at": null,
@@ -665,4 +665,4 @@ This endpoint allows you to create assignments for a user.
 Parameter | Required | Type |  Description
 --- | --- | --- | ---
 user_id | yes | Positive Integer | The user to access.  The company must have access to the user.
-assignments | yes | Array |  Array of assignments to be made to the user.  Each requires an assignable_id and assignable_type of "Lesson" or "Course". By default, an email will be sent to the assignee; it will come from notifications@lessonly.com. To suppress the email notification set `notify` to `false`.
+assignments | yes | Array |  Array of assignments to be made to the user.  Each requires an assignable_id and assignable_type of "Lesson" or "Path". By default, an email will be sent to the assignee; it will come from notifications@lessonly.com. To suppress the email notification set `notify` to `false`.

--- a/source/index.md
+++ b/source/index.md
@@ -14,6 +14,7 @@ includes:
   - groups
   - lessons
   - courses
+  - paths
   - tags
   - assignments
   - company_settings


### PR DESCRIPTION
[Resolves](https://app.clubhouse.io/lessonly/story/6538/add-api-documentation-for-path-endpoint-usage)

Adds all Path related API endpoints to the documentation

## Testing Notes

Take a look at the Clubhouse story's attached paths_api.txt for reference
- [x] All endpoints are described correctly
- [x] Any missing endpoints?
- [x] Spelling & grammar

## Merge Notes

We probably don't want to merge this until Paths API is public.

**Steve update:** Correct! And we'll consider the Paths API public once we release Paths for new customers. So by all means let's review this and make sure it's 💯, but hold off on merging (and deploying with `rake publish`) until we've switched new customers from Courses to Paths.