### PR TITLE
Fix typo and restructure sentence

### DIFF
--- a/source/includes/_introduction.md
+++ b/source/includes/_introduction.md
@@ -3,4 +3,4 @@
 
 Welcome to the Lessonly API documentation! First you will need to get an API key by signing into your account, navigating to the company settings page and clicking "Show API credentials".
 
-Currently we only have language bindings for shell, however we are open to providing libraries in other libraries.  Contact us to let us know what libraries you would like to see to connect with Lessonly:  [here] (mailto:info@lessonly.com).
+Currently we only have language bindings for shell, however we are open to providing libraries in other languages. Contact us at [info@lessonly.com] (mailto:info@lessonly.com) to let us know what libraries you would like to see.


### PR DESCRIPTION
Resolves [[ch8530]](https://app.clubhouse.io/lessonly/story/8530/api-fix-typo)

- Fixed typo "libraries in other libraries" → "libraries in other languages"
- Removed extra spaces
- Restructured the contact-us sentence

```diff
-Currently we only have language bindings for shell, however we are open to providing libraries in other libraries.  Contact us to let us know what libraries you would like to see to connect with Lessonly:  [here] (mailto:info@lessonly.com).
+Currently we only have language bindings for shell, however we are open to providing libraries in other languages. Contact us at [info@lessonly.com] (mailto:info@lessonly.com) to let us know what libraries you would like to see.
```

**Before**

![screen shot 2018-02-01 at 3 17 47 pm](https://user-images.githubusercontent.com/2100222/35701136-150c2bfa-0763-11e8-93a5-b0076f0ce7be.png)


**After**

![screen shot 2018-02-01 at 3 17 25 pm](https://user-images.githubusercontent.com/2100222/35701116-06a935ee-0763-11e8-806f-bc0b964c1386.png)
