### PR TITLE
Document additions to the /users, /lessons, and /paths API endpoints

### DIFF
--- a/source/includes/_lessons.md.erb
+++ b/source/includes/_lessons.md.erb
@@ -21,16 +21,16 @@ curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/lessons"
         "public": false,
         "created_at": "2020-09-30T00:00:00Z",
         "last_updated_at": "2020-09-30T00:00:00Z",
-        "tags" : [
+        "tags": [
           {
             "id": 1,
             "name": "test_tag",
             "resource_type": "tag"
           }
         ],
-        "links" : {
+        "links": {
           "overview": "https://mycompany.lessonly.com/lessons/1-first-lesson"
-        },
+        }
       },
       {
         "id": 2,
@@ -41,18 +41,18 @@ curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/lessons"
         "public": true,
         "created_at": "2020-09-30T00:00:00Z",
         "last_updated_at": "2020-09-30T00:00:00Z",
-        "tags" : [
+        "tags": [
           {
             "id": 1,
             "name": "test_tag",
             "resource_type": "tag"
           }
         ],
-        "links" : {
+        "links": {
           "overview": "https://mycompany.lessonly.com/lessons/2-second-lesson",
           "shareable": "https://mycompany.lessonly.com/lesson/2-second-lesson"
-        },
-      },
+        }
+      }
     ]
 }
 ```
@@ -83,14 +83,14 @@ curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/lessons/:lesson_id
   "public": false,
   "created_at": "2020-09-30T00:00:00Z",
   "last_updated_at": "2020-09-30T00:00:00Z",
-  "tags" : [
+  "tags": [
     {
       "id": 1,
       "name": "test_tag",
       "resource_type": "tag"
     }
   ],
-  "links" : {
+  "links": {
     "overview": "https://mycompany.lessonly.com/lessons/1-lesson-1",
     "shareable": "https://mycompany.lessonly.com/lesson/1-lesson-1"
   },
@@ -122,13 +122,13 @@ curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1.1/lessons/:lesson_id
   "public": false,
   "created_at": "2020-09-30T00:00:00Z",
   "last_updated_at": "2020-09-30T00:00:00Z",
-  "tags" : [
+  "tags": [
     {
       "id": 1,
       "name": "test_tag"
     }
   ],
-  "links" : {
+  "links": {
     "shareable": "https://lesson-shareable-link"
   }
 }
@@ -160,13 +160,13 @@ curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/lessons/:lesson_id -d 
   "public": false,
   "created_at": "2020-09-30T00:00:00Z",
   "last_updated_at": "2020-09-30T00:00:00Z",
-  "tags" : [
+  "tags": [
     {
       "id": 1,
       "name": "test_tag"
     }
   ],
-  "links" : {
+  "links": {
     "overview": "https://mycompany.lessonly.com/lessons/1-lesson-1",
     "shareable": "https://mycompany.lessonly.com/lesson/1-lesson-1"
   }

--- a/source/includes/_lessons.md.erb
+++ b/source/includes/_lessons.md.erb
@@ -16,13 +16,42 @@ curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/lessons"
         "id": 1,
         "title": "First Lesson",
         "archived_at": null,
-        "archived_by_user_id": null
+        "archived_by_user_id": null,
+        "retake_score": 80,
+        "public": false,
+        "created_at": "2020-09-30T00:00:00Z",
+        "last_updated_at": "2020-09-30T00:00:00Z",
+        "tags" : [
+          {
+            "id": 1,
+            "name": "test_tag",
+            "resource_type": "tag"
+          }
+        ],
+        "links" : {
+          "overview": "https://mycompany.lessonly.com/lessons/1-first-lesson"
+        },
       },
       {
         "id": 2,
         "title": "Second Lesson",
         "archived_at": null,
-        "archived_by_user_id": null
+        "archived_by_user_id": null,
+        "retake_score": 95,
+        "public": true,
+        "created_at": "2020-09-30T00:00:00Z",
+        "last_updated_at": "2020-09-30T00:00:00Z",
+        "tags" : [
+          {
+            "id": 1,
+            "name": "test_tag",
+            "resource_type": "tag"
+          }
+        ],
+        "links" : {
+          "overview": "https://mycompany.lessonly.com/lessons/2-second-lesson",
+          "shareable": "https://mycompany.lessonly.com/lesson/2-second-lesson"
+        },
       },
     ]
 }

--- a/source/includes/_paths.md.erb
+++ b/source/includes/_paths.md.erb
@@ -16,13 +16,44 @@ curl -u "DOMAIN:API_KEY" "https://api.lessonly.com/api/v1/paths"
       "id": 1,
       "title": "Path 1",
       "archived_at": null,
-      "archived_by_user_id": null
+      "archived_by_user_id": null,
+      "public": false,
+      "created_at": "2017-07-24T10:47:23Z",
+      "last_updated_at": "2017-07-24T10:49:10Z",
+      "published_at": null,
+      "publisher_id": null,
+      "tags": [
+        {
+          "id": 1,
+          "resource_type": "tag",
+          "name": "Engineering"
+        }
+      ],
+      "links": {
+        "overview": "https://mycompany.lessonly.com/paths/1-path-1"
+      }
     },
     {
       "id": 2,
       "title": "Path 2",
       "archived_at": "2017-06-28T10:46:03.467-04:00",
-      "archived_by_user_id": 123
+      "archived_by_user_id": 123,
+      "public": true,
+      "created_at": "2017-07-24T10:47:23Z",
+      "last_updated_at": "2017-07-24T10:49:10Z",
+      "published_at": "2017-08-21T11:16:22Z",
+      "publisher_id": 1234,
+      "tags": [
+        {
+          "id": 1,
+          "resource_type": "tag",
+          "name": "Engineering"
+        }
+      ],
+      "links": {
+        "shareable": "https://mycompany.lessonly.com/path/2-path-2",
+        "overview": "https://mycompany.lessonly.com/paths/2-path-2"
+      }
     }
   ]
 }

--- a/source/includes/_users.md.erb
+++ b/source/includes/_users.md.erb
@@ -30,7 +30,15 @@
         "department": "Sales",
         "location": "Illinois",
         "hire_date": "2014-12-25",
-        "manager_name": "Mary Doe"
+        "manager_name": "Mary Doe",
+        "custom_user_field_data": [
+          {
+            "id": 1,
+            "custom_user_field_id": 1,
+            "name": "Custom Field Name 1",
+            "value": "Custom Value 1"
+          }
+        ]
       },
       {
         "id": 2,
@@ -45,7 +53,15 @@
         "department": "IT",
         "location": "California",
         "hire_date": "2014-12-25",
-        "manager_name": "Jane Doe"
+        "manager_name": "Jane Doe",
+        "custom_user_field_data": [
+          {
+            "id": 2,
+            "custom_user_field_id": 1,
+            "name": "Custom Field Name 1",
+            "value": "Custom Value 2"
+          }
+        ]
       }
     ]
 }


### PR DESCRIPTION
This PR updates the API doc for API updates in these PRs:

https://github.com/lessonly/lessonly/pull/4739
Added custom user fields to `GET /api/v1.1/users`

https://github.com/lessonly/lessonly/pull/4751
Added tags to `GET /api/v1.1/lessons`

https://github.com/lessonly/lessonly/pull/4756
Added tags to `GET /api/v1.1/paths`

