### PR TITLE
Mark the Courses API endpoints as deprecated

### DIFF
--- a/source/includes/_courses.md.erb
+++ b/source/includes/_courses.md.erb
@@ -1,4 +1,4 @@
-# Courses
+# Courses <span class="deprecation-warning">(Deprecated)</span>
 
 ## List Courses
 

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -639,4 +639,16 @@ html, body {
   }
 }
 
+.deprecation-warning {
+  background-color: #fff3cd;
+  border: 1px solid #ffeeba;
+  color: #856404;
+  font-size: 16px;
+  padding: .25em;
+  border-radius: .25em;
+  vertical-align: middle;
 
+  &:before {
+    content: '⚠️';
+  }
+}


### PR DESCRIPTION
## Why

Resolves [[ch12674]](https://app.clubhouse.io/lessonly/story/12674/mark-the-course-api-docs-as-deprecated)

Courses are being replaced by Paths. While most of our customers have transitioned, we should indicate to folks still building on Courses API endpoints that it is no longer the recommended way.

## What

<img width="654" alt="screen shot 2018-07-02 at 10 03 24 am" src="https://user-images.githubusercontent.com/664341/42168649-8f651946-7ddf-11e8-983a-6d7976659db1.png">

## Testing Notes

- Check out this branch
- Run `bundle exec middleman`
- Preview the changes at <http://localhost:4567>

## Merge Instructions

Post-merge, we'll need to push these changes live with `bundle exec rake publish`