### PR TITLE
Update API docs to explicitly say only completed assignments can be reassigned

### DIFF
--- a/source/includes/_courses.md.erb
+++ b/source/includes/_courses.md.erb
@@ -384,4 +384,4 @@ This endpoint allows you to make assignments to a particular course in the API.
 Parameter | Required | Type |  Description
 --- | --- | --- | ---
 course_id | yes | Positive Integer | The course to access. The company must have access to the user.
-assignments | no | Hash | A hash of assignments to be made to the course.  If the assignment for a particular user already exists, the user will be reassigned the course. By default, an email will be sent to the assignee; it will come from notifications@lessonly.com. To suppress the email notification set `notify` to `false`.
+assignments | no | Hash | A hash of assignments to be made to the course.  If the assignment for a particular user already exists, the user will be reassigned the course (Only completed assignments will be reassigned). By default, an email will be sent to the assignee; it will come from notifications@lessonly.com. To suppress the email notification set `notify` to `false`.

--- a/source/includes/_courses.md.erb
+++ b/source/includes/_courses.md.erb
@@ -384,4 +384,4 @@ This endpoint allows you to make assignments to a particular course in the API.
 Parameter | Required | Type |  Description
 --- | --- | --- | ---
 course_id | yes | Positive Integer | The course to access. The company must have access to the user.
-assignments | no | Hash | A hash of assignments to be made to the course.  If the assignment for a particular user already exists, the user will be reassigned the course (Only completed assignments will be reassigned). By default, an email will be sent to the assignee; it will come from notifications@lessonly.com. To suppress the email notification set `notify` to `false`.
+assignments | no | Hash | A hash of assignments to be made to the course.  If the assignment for a particular user already exists, the user will be reassigned the course (only completed assignments will be reassigned). By default, an email will be sent to the assignee; it will come from notifications@lessonly.com. To suppress the email notification set `notify` to `false`.

--- a/source/includes/_lessons.md.erb
+++ b/source/includes/_lessons.md.erb
@@ -418,4 +418,4 @@ This endpoint allows you to make assignments to a particular lesson in the API.
 Parameter | Required | Type |  Description
 --- | --- | --- | ---
 lesson_id | yes | Positive Integer | The lesson to access.  The company must have access to the user.
-assignments | no | Hash | A hash of assignments to be made to the lesson.  If the assignment for a particular user already exists, the user will be reassigned the lesson. By default, an email will be sent to the assignee; it will come from notifications@lessonly.com. To suppress the email notification set `notify` to `false`.
+assignments | no | Hash | A hash of assignments to be made to the lesson.  If the assignment for a particular user already exists, the user will be reassigned the lesson (Only completed assignments will be reassigned). By default, an email will be sent to the assignee; it will come from notifications@lessonly.com. To suppress the email notification set `notify` to `false`.

--- a/source/includes/_lessons.md.erb
+++ b/source/includes/_lessons.md.erb
@@ -418,4 +418,4 @@ This endpoint allows you to make assignments to a particular lesson in the API.
 Parameter | Required | Type |  Description
 --- | --- | --- | ---
 lesson_id | yes | Positive Integer | The lesson to access.  The company must have access to the user.
-assignments | no | Hash | A hash of assignments to be made to the lesson.  If the assignment for a particular user already exists, the user will be reassigned the lesson (Only completed assignments will be reassigned). By default, an email will be sent to the assignee; it will come from notifications@lessonly.com. To suppress the email notification set `notify` to `false`.
+assignments | no | Hash | A hash of assignments to be made to the lesson.  If the assignment for a particular user already exists, the user will be reassigned the lesson (only completed assignments will be reassigned). By default, an email will be sent to the assignee; it will come from notifications@lessonly.com. To suppress the email notification set `notify` to `false`.

--- a/source/includes/_paths.md.erb
+++ b/source/includes/_paths.md.erb
@@ -385,7 +385,7 @@ This endpoint allows you to make assignments to a particular path in the API.
 Parameter | Required | Type |  Description
 --- | --- | --- | ---
 path_id | yes | Positive Integer | The path to access. The company must have access to the path.
-assignments | no | Hash | A hash of assignments to be made to the path.  If the assignment for a particular user already exists, the user will be reassigned the path (Only completed assignments will be reassigned). By default, an email will be sent to the assignee; it will come from notifications@lessonly.com. To suppress the email notification set `notify` to `false`.
+assignments | no | Hash | A hash of assignments to be made to the path.  If the assignment for a particular user already exists, the user will be reassigned the path (only completed assignments will be reassigned). By default, an email will be sent to the assignee; it will come from notifications@lessonly.com. To suppress the email notification set `notify` to `false`.
 
 ## List Path Assignments
 

--- a/source/includes/_paths.md.erb
+++ b/source/includes/_paths.md.erb
@@ -385,7 +385,7 @@ This endpoint allows you to make assignments to a particular path in the API.
 Parameter | Required | Type |  Description
 --- | --- | --- | ---
 path_id | yes | Positive Integer | The path to access. The company must have access to the path.
-assignments | no | Hash | A hash of assignments to be made to the path.  If the assignment for a particular user already exists, the user will be reassigned the path. By default, an email will be sent to the assignee; it will come from notifications@lessonly.com. To suppress the email notification set `notify` to `false`.
+assignments | no | Hash | A hash of assignments to be made to the path.  If the assignment for a particular user already exists, the user will be reassigned the path (Only completed assignments will be reassigned). By default, an email will be sent to the assignee; it will come from notifications@lessonly.com. To suppress the email notification set `notify` to `false`.
 
 ## List Path Assignments
 


### PR DESCRIPTION
## Why

Resolves [[ch17781]](https://app.clubhouse.io/lessonly/story/17781)

We want the API docs to say only completed assignments can be reassigned.
Do this for lessons, courses and paths.

## What

Add message that "Only completed assignments will be reassigned".

## Testing Notes

- Check out to this branch
- Run `bundle exec middleman`
- Preview the changes at http://localhost:4567

## Merge Instructions

Post-merge, we'll need to push these changes live with `bundle exec rake publish`