### PR TITLE
Correcting API Documentation [ch26315]

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -10,8 +10,8 @@ set :markdown,
     no_intra_emphasis: true
 
 helpers do
-  def api_get_request(endpoint)
-    "curl -u \"SUBDOMAIN:API_KEY\" \"https://api.lessonly.com/api/v1#{endpoint}\""
+  def api_get_request(endpoint, version = 'v1')
+    "curl -u \"SUBDOMAIN:API_KEY\" \"https://api.lessonly.com/api/#{version}#{endpoint}\""
   end
 
   def post_request(endpoint)

--- a/source/includes/_assignments.md.erb
+++ b/source/includes/_assignments.md.erb
@@ -20,6 +20,7 @@ curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1/assignments"
       "id": 1,
       "resource_type": "assignment",
       "assignee_id": 1,
+      "score": 90,
       "assignable_type": "Lesson",
       "assignable_id": 1,
       "ext_uid": "ABC123",
@@ -35,6 +36,7 @@ curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1/assignments"
       "id": 2,
       "resource_type": "assignment",
       "assignee_id": 2,
+      "score": null,
       "assignable_type": "LearningPaths::Path",
       "assignable_id": 1,
       "ext_uid": "DEF456",
@@ -49,6 +51,7 @@ curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1/assignments"
       "id": 3,
       "resource_type": "assignment",
       "assignee_id": 3,
+      "score": 100,
       "assignable_type": "LearningPaths::Path",
       "assignable_id": 1,
       "ext_uid": "DEF456",
@@ -63,6 +66,7 @@ curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1/assignments"
       "id": 4,
       "resource_type": "assignment",
       "assignee_id": 4,
+      "score": 80,
       "assignable_type": "LearningPaths::Path",
       "assignable_id": 1,
       "ext_uid": "DEF456",
@@ -107,22 +111,40 @@ curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1/assignments/:status
   "page": 1,
   "per_page": 2,
   "total_pages": 1000,
-  "assignments":[
-    {
-      "id": 2,
-      "resource_type": "assignment",
-      "assignee_id": 2,
-      "assignable_type": "LearningPaths::Path",
-      "assignable_id": 1,
-      "ext_uid": "DEF456",
-      "due_by": "2020-09-30T00:00:00Z",
-      "reassigned_at": "2020-09-30T00:00:00Z",
-      "status": "Incomplete",
-      "started_at": "2016-03-28T14:15:17Z",
-      "completed_at": null,
-      "updated_at": "2016-03-28T18:20:06Z"
-    }
-  ]
+  "assignments": [
+      {
+          "id": 5566,
+          "resource_type": "assignment",
+          "assignee_id": 1735,
+          "assignable_type": "Lesson",
+          "assignable_id": 855,
+          "ext_uid": "5745967403",
+          "assigned_at": "2014-01-20T20:07:07Z",
+          "due_by": "2014-05-13T04:00:00Z",
+          "reassigned_at": "2014-05-07T18:33:46Z",
+          "status": "Completed",
+          "updated_at": "2015-10-08T19:58:28Z",
+          "score": 100,
+          "started_at": "2014-08-04T14:31:42Z",
+          "completed_at": "2014-08-04T14:36:16Z"
+      },
+      {
+          "id": 6876654,
+          "resource_type": "assignment",
+          "assignee_id": 3120575,
+          "assignable_type": "LearningPaths::Path",
+          "assignable_id": 19433,
+          "ext_uid": null,
+          "assigned_at": "2018-12-12T13:02:21Z",
+          "due_by": null,
+          "reassigned_at": null,
+          "status": "Incomplete",
+          "updated_at": "2018-12-13T18:35:40Z",
+          "score": null,
+          "started_at": "2018-12-13T18:35:40Z",
+          "completed_at": null
+      }
+]
 }
 ```
 
@@ -137,3 +159,4 @@ This endpoint retrieves all assignments by their status.
 Parameter | Required | Type |  Description
 --- | --- | --- | ---
 status | yes | String | An assignment status. Supported statues are: incomplete, completed, overdue, or grade_pending
+<%= pagination_query_params.chomp %>

--- a/source/includes/_groups.md.erb
+++ b/source/includes/_groups.md.erb
@@ -125,10 +125,9 @@ group_id | yes | Positive Integer | The group to access.  The company must have 
       {"id":  3 },
       {"id":  4 }
     ]
-
 }
 ```
-> A successful update will return JSON consisting of the group details repsonse:
+> A successful post will return JSON consisting of the group details response:
 
 ```json
 {
@@ -136,18 +135,84 @@ group_id | yes | Positive Integer | The group to access.  The company must have 
   "resource_type": "group",
   "id": 12345,
   "name": "New Name",
+  "archived_at": null,
+  "archived_by_user_id": null,
   "members": [
-         {"id": 1, "ext_uid": "ABC123", "name": "Test Name 1"},
-         {"id": 2, "ext_uid": "ABC123", "name": "Test Name 2"}
-    ],
+    {
+      "id": 1,
+      "resource_type": "user",
+      "ext_uid": null,
+      "email": "joe.alec@lessonly.com",
+      "name": "Joe Alec",
+      "role": "admin",
+      "archived_at": null,
+      "archived_by_user_id": null,
+      "job_title": "",
+      "business_unit": "Andela",
+      "department": "Product",
+      "location": "",
+      "locale": "en",
+      "hire_date": null,
+      "manager_name": "Joe Metil"
+    },
+    {
+      "id": 2,
+      "resource_type": "user",
+      "ext_uid": null,
+      "email": "me@lessonly.com",
+      "name": "Henry Alec",
+      "role": "admin",
+      "archived_at": null,
+      "archived_by_user_id": null,
+      "job_title": "",
+      "business_unit": "Andela",
+      "department": "Product",
+      "location": "",
+      "locale": "en",
+      "hire_date": null,
+      "manager_name": "Joe Metil"
+    }
+   ],
   "managers":  [
-         {"id": 3, "ext_uid": "JKL012", "name": "Test Name 3"},
-         {"id": 4, "ext_uid": "JKL012", "name": "Test Name 4"}
+     {
+        "id": 3,
+        "resource_type": "user",
+        "ext_uid": "9083042864",
+        "email": "jay@lessonly.com",
+        "name": "Jay Bentley",
+        "role": "manager",
+        "archived_at": null,
+        "archived_by_user_id": null,
+        "job_title": "",
+        "business_unit": "",
+        "department": "Product",
+        "location": "",
+        "locale": "en",
+        "hire_date": null,
+        "manager_name": ""
+     },
+     {
+        "id": 4,
+        "resource_type": "user",
+        "ext_uid": "9083042864",
+        "email": "irene@lessonly.com",
+        "name": "Sandra Irene",
+        "role": "manager",
+        "archived_at": null,
+        "archived_by_user_id": null,
+        "job_title": "",
+        "business_unit": "",
+        "department": "Product",
+        "location": "",
+        "locale": "en",
+        "hire_date": null,
+        "manager_name": ""
+     }
    ]
 }
 ```
 
-This endpoint allows you to create a group and its members and managers.
+This endpoint allows you to create a group, its members and managers.
 
 ### HTTP Request
 
@@ -187,7 +252,7 @@ managers | no | Array | The managers of a group.
 
 }
 ```
-> A successful update will return JSON consisting of the group details repsonse:
+> A successful update will return JSON consisting of the group details response:
 
 ```json
 {
@@ -195,16 +260,50 @@ managers | no | Array | The managers of a group.
   "resource_type": "group",
   "id": 12345,
   "name": "New Name",
+  "archived_at": null,
+  "archived_by_user_id": null,
   "members": [
-         {"id": 1, "ext_uid": "ABC123", "name": "Test Name 1"},
-    ],
+    {
+      "id": 1,
+      "resource_type": "user",
+      "ext_uid": null,
+      "email": "me@lessonly.com",
+      "name": "Henry Alec",
+      "role": "learner",
+      "archived_at": null,
+      "archived_by_user_id": null,
+      "job_title": "",
+      "business_unit": "Andela",
+      "department": "Product",
+      "location": "",
+      "locale": "en",
+      "hire_date": null,
+      "manager_name": "Joe Metil"
+    }
+  ],
   "managers":  [
-         {"id": 4, "ext_uid": "JKL012", "name": "Test Name 4"},
+     {
+        "id": 4,
+        "resource_type": "user",
+        "ext_uid": "9083042864",
+        "email": "irene@lessonly.com",
+        "name": "Sandra Irene",
+        "role": "manager",
+        "archived_at": null,
+        "archived_by_user_id": null,
+        "job_title": "",
+        "business_unit": "",
+        "department": "Product",
+        "location": "",
+        "locale": "en",
+        "hire_date": null,
+        "manager_name": ""
+     }
    ]
 }
 ```
 
-This endpoint allows you to update a group and its members and managers.
+This endpoint allows you to update a group, its members and managers.
 
 ### HTTP Request
 
@@ -229,20 +328,51 @@ managers | no | Array | The managers of a group.  Passing "remove": "true" will 
 
 ```json
 {
-    "archived_at": "2016-09-26T13:05:01.174-04:00",
-    "archived_by_user_id": null,
     "id": 12631,
-    "members": [
-           {"id": 1, "ext_uid": "ABC123", "name": "Test Name 1"}
-      ],
-    "managers":  [
-           {"id": 4, "ext_uid": "JKL012", "name": "Test Name 4"}
-     ],
     "name": "Developer",
     "resource_type": "group",
-    "type": "group"
+    "type": "group",
+    "archived_at": "2016-09-26T13:05:01.174-04:00",
+    "archived_by_user_id": null,
+    "members": [
+      {
+        "id": 1,
+        "resource_type": "user",
+        "ext_uid": null,
+        "email": "me@lessonly.com",
+        "name": "Henry Alec",
+        "role": "learner",
+        "archived_at": null,
+        "archived_by_user_id": null,
+        "job_title": "",
+        "business_unit": "Andela",
+        "department": "Product",
+        "location": "",
+        "locale": "en",
+        "hire_date": null,
+        "manager_name": "Joe Metil"
+      }
+    ],
+    "managers": [
+       {
+          "id": 4,
+          "resource_type": "user",
+          "ext_uid": "9083042864",
+          "email": "irene@lessonly.com",
+          "name": "Sandra Irene",
+          "role": "manager",
+          "archived_at": null,
+          "archived_by_user_id": null,
+          "job_title": "",
+          "business_unit": "",
+          "department": "Product",
+          "location": "",
+          "locale": "en",
+          "hire_date": null,
+          "manager_name": ""
+       }
+    ]
 }
-
 ```
 
 This endpoint allows the archiving of a single group.
@@ -267,18 +397,50 @@ group_id | yes | Positive Integer | The group to archive.  The company must have
 
 ```json
 {
+    "id": 12631,
+    "name": "Developer",
+    "resource_type": "group",
+    "type": "group",
     "archived_at": null,
     "archived_by_user_id": null,
-    "id": 12631,
     "members": [
-        {"id": 1, "ext_uid": "ABC123", "name": "Test Name 1"}
-     ],
-    "managers":  [
-        {"id": 4, "ext_uid": "JKL012", "name": "Test Name 4"}
-     ],
-    "name": "/",
-    "resource_type": "group",
-    "type": "group"
+      {
+        "id": 1,
+        "resource_type": "user",
+        "ext_uid": null,
+        "email": "me@lessonly.com",
+        "name": "Henry Alec",
+        "role": "learner",
+        "archived_at": null,
+        "archived_by_user_id": null,
+        "job_title": "",
+        "business_unit": "Andela",
+        "department": "Product",
+        "location": "",
+        "locale": "en",
+        "hire_date": null,
+        "manager_name": "Joe Metil"
+      }
+    ],
+    "managers": [
+       {
+          "id": 4,
+          "resource_type": "user",
+          "ext_uid": "9083042864",
+          "email": "irene@lessonly.com",
+          "name": "Sandra Irene",
+          "role": "manager",
+          "archived_at": null,
+          "archived_by_user_id": null,
+          "job_title": "",
+          "business_unit": "",
+          "department": "Product",
+          "location": "",
+          "locale": "en",
+          "hire_date": null,
+          "manager_name": ""
+       }
+    ]
 }
 ```
 

--- a/source/includes/_groups.md.erb
+++ b/source/includes/_groups.md.erb
@@ -23,7 +23,7 @@ curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1/groups"
       "name": "Group 2",
       "archived_at": null,
       "archived_by_user_id": null
-    },
+    }
   ]
 }
 ```
@@ -44,19 +44,50 @@ curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1/groups/:group_id"
 
 ```json
 {
+  "id": 12345,
   "type": "group",
   "resource_type": "group",
-  "id": 12345,
   "name": "Test Group",
+  "archived_at": null,
+  "archived_by_user_id": null,
   "members": [
-         {"id": 1, "ext_uid": "ABC123", "name": "Test Name"},
-         {"id": 2, "ext_uid": "DEF456", "name": "Test Name 2"}
-    ],
-  "managers":  [
-         {"id": 1, "ext_uid": "ABC123", "name": "Test Name"},
-   ],
-   "archived_at": null,
-   "archived_by_user_id": null
+    {
+        "id": 4308512,
+        "resource_type": "user",
+        "ext_uid": null,
+        "email": "joe.alec@lessonly.com",
+        "name": "Joe Alec",
+        "role": "admin",
+        "archived_at": null,
+        "archived_by_user_id": null,
+        "job_title": "",
+        "business_unit": "Andela",
+        "department": "Product",
+        "location": "",
+        "locale": "en",
+        "hire_date": null,
+        "manager_name": "Joe Metil"
+    }
+  ],
+  "managers": [
+      {
+          "id": 21494,
+          "resource_type": "user",
+          "ext_uid": "9083042864",
+          "email": "jay@lessonly.com",
+          "name": "Jay Bentley",
+          "role": "manager",
+          "archived_at": null,
+          "archived_by_user_id": null,
+          "job_title": "",
+          "business_unit": "",
+          "department": "Product",
+          "location": "",
+          "locale": "en",
+          "hire_date": null,
+          "manager_name": ""
+      }
+   ]
 }
 ```
 
@@ -207,10 +238,11 @@ managers | no | Array | The managers of a group.  Passing "remove": "true" will 
     "managers":  [
            {"id": 4, "ext_uid": "JKL012", "name": "Test Name 4"}
      ],
-    "name": "/",
+    "name": "Developer",
     "resource_type": "group",
     "type": "group"
 }
+
 ```
 
 This endpoint allows the archiving of a single group.
@@ -239,10 +271,10 @@ group_id | yes | Positive Integer | The group to archive.  The company must have
     "archived_by_user_id": null,
     "id": 12631,
     "members": [
-           {"id": 1, "ext_uid": "ABC123", "name": "Test Name 1"}
-      ],
+        {"id": 1, "ext_uid": "ABC123", "name": "Test Name 1"}
+     ],
     "managers":  [
-           {"id": 4, "ext_uid": "JKL012", "name": "Test Name 4"}
+        {"id": 4, "ext_uid": "JKL012", "name": "Test Name 4"}
      ],
     "name": "/",
     "resource_type": "group",
@@ -268,7 +300,7 @@ group_id | yes | Positive Integer | The group to restore.  The company must have
 curl -X DELETE -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1/groups/:group_id"
 ```
 
-> A successful update returns JSON consisting of the id of the deleted group
+> A successful delete returns JSON consisting of the id of the deleted group
 
 ```json
 {

--- a/source/includes/_introduction.md
+++ b/source/includes/_introduction.md
@@ -1,6 +1,6 @@
 
 # Introduction
 
-Welcome to the Lessonly API documentation! First you will need to get an API key by signing into your account, navigating to the company settings page and clicking "Show API credentials".
+Welcome to the Lessonly API documentation! First you will need to get an API key by signing into your account, navigating to the company settings page and clicking "API & Webhook".
 
 Currently we only have language bindings for shell, however we are open to providing libraries in other languages. Contact us at [info@lessonly.com] (mailto:info@lessonly.com) to let us know what libraries you would like to see.

--- a/source/includes/_lessons.md.erb
+++ b/source/includes/_lessons.md.erb
@@ -110,13 +110,14 @@ curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1/lessons/:lesson_id
 
 ```json
 {
+  "id": 1,
   "type": "lesson",
   "resource_type": "lesson",
-  "id": 1,
   "title": "Lesson 1",
   "assignees_count": 10,
   "completed_count": 5,
   "retake_score": 80,
+  "description": "just another lesson",
   "public": false,
   "created_at": "2020-09-30T00:00:00Z",
   "last_updated_at": "2020-09-30T00:00:00Z",
@@ -151,23 +152,28 @@ curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1.1/lessons/:lesson_i
 
 ```json
 {
+  "id": 1,
   "type": "lesson",
   "resource_type": "lesson",
-  "id": 1,
   "title": "Lesson 1",
   "retake_score": 80,
+  "description": "just another lesson",
   "public": false,
   "created_at": "2020-09-30T00:00:00Z",
   "last_updated_at": "2020-09-30T00:00:00Z",
   "tags": [
     {
       "id": 1,
+      "resource_type": "tag",
       "name": "test_tag"
     }
   ],
   "links": {
-    "shareable": "https://lesson-shareable-link"
-  }
+    "shareable": "https://lesson-link",
+    "overview": "https://lesson-link"
+  },
+  "archived_at": "2016-08-12T08:54:52.982-04:00",
+  "archived_by_user_id": 78
 }
 ```
 
@@ -180,7 +186,7 @@ This endpoint retrieves the lesson's information. For a count of completed assig
 ## Update Lesson
 
 ```shell
-curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1/lessons/:lesson_id -d params
+curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1/lessons/:lesson_id" -d params
 ```
 
 > The above command returns JSON structured like this:
@@ -191,12 +197,15 @@ curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1/lessons/:lesson_id 
   "resource_type": "lesson",
   "id": 1,
   "title": "Lesson 1",
+  "description": "just another lesson",
   "assignees_count": 10,
   "completed_count": 5,
   "retake_score": 80,
   "public": false,
   "created_at": "2020-09-30T00:00:00Z",
   "last_updated_at": "2020-09-30T00:00:00Z",
+  "archived_at": null,
+  "archived_by_user_id": null,
   "tags": [
     {
       "id": 1,
@@ -235,13 +244,15 @@ public | no | Boolean | Whether or not the lesson is public
 
 ```json
 {
+    "id": 43530,
+    "title": "Untitled Lesson",
+    "type": "lesson",
     "archived_at": "2016-10-12T16:12:09.850-04:00",
     "archived_by_user_id": null,
     "assignees_count": 0,
     "completed_count": 0,
     "created_at": "2016-10-06T16:09:41Z",
     "description": null,
-    "id": 43530,
     "last_updated_at": "2016-10-06T16:18:01Z",
     "links": {
       "overview": "https://mycompany.lessonly.com/lessons/43530-untitled-lesson",
@@ -253,11 +264,10 @@ public | no | Boolean | Whether or not the lesson is public
     "tags": [
       {
         "id": 1,
-        "name": "test_tag"
+        "name": "test_tag",
+        "resource_type": "tag"
       }
-    ],
-    "title": "Untitled Lesson",
-    "type": "lesson"
+    ]
 }
 ```
 
@@ -283,13 +293,15 @@ lesson_id | yes | Positive Integer | The lesson to archive.  The company must ha
 
 ```json
 {
+    "id": 43530,
+    "title": "Untitled Lesson",
+    "type": "lesson",
     "archived_at": null,
     "archived_by_user_id": null,
     "assignees_count": 0,
     "completed_count": 0,
     "created_at": "2016-10-06T16:09:41Z",
     "description": null,
-    "id": 43530,
     "last_updated_at": "2016-10-06T16:18:01Z",
     "links": {
       "overview": "https://mycompany.lessonly.com/lessons/43530-untitled-lesson",
@@ -301,11 +313,10 @@ lesson_id | yes | Positive Integer | The lesson to archive.  The company must ha
     "tags": [
       {
         "id": 1,
-        "name": "test_tag"
+        "name": "test_tag",
+        "resource_type": "tag"
       }
-    ],
-    "title": "Untitled Lesson",
-    "type": "lesson"
+    ]
 }
 ```
 

--- a/source/includes/_lessons.md.erb
+++ b/source/includes/_lessons.md.erb
@@ -11,9 +11,44 @@ curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1/lessons"
 ```json
 {
   "type": "lessons",
+  "lessons": [
+      {
+        "id": 30976,
+        "title": "Lesson 3",
+        "archived_at": "2016-08-08T10:49:37.676-04:00",
+        "archived_by_user_id": 1735
+      },
+      {
+        "id": 94861,
+        "title": "Trent - Kendra Scott",
+        "archived_at": "2018-02-10T15:38:51.014-05:00",
+        "archived_by_user_id": 78
+      }
+  ]
+}
+```
+
+This endpoint retrieves all lessons.
+
+### HTTP Request
+
+`GET https://api.lessonly.com/api/v1/lessons`
+
+## List Lessons (v1.1)
+
+```shell
+curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1.1/lessons"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "type": "lessons",
   "lessons":[
       {
         "id": 1,
+        "resource_type": "lesson",
         "title": "First Lesson",
         "archived_at": null,
         "archived_by_user_id": null,
@@ -34,6 +69,7 @@ curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1/lessons"
       },
       {
         "id": 2,
+        "resource_type": "lesson",
         "title": "Second Lesson",
         "archived_at": null,
         "archived_by_user_id": null,
@@ -61,7 +97,8 @@ This endpoint retrieves all lessons.
 
 ### HTTP Request
 
-`GET https://api.lessonly.com/api/v1/lessons`
+`GET https://api.lessonly.com/api/v1.1/lessons`
+
 
 ## Show Lesson Details
 
@@ -304,10 +341,13 @@ curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1/lessons/:lesson_id/
       "id": 1,
       "resource_type": "assignment",
       "assignee_id": 1,
+      "assignable_type": "Lesson",
+      "assignable_id": 12,
       "ext_uid": "ABC123",
       "due_by": "2020-09-30T00:00:00Z",
       "assigned_at": "2020-03-20T00:00:00Z",
       "reassigned_at": "2020-09-30T00:00:00Z",
+      "started_at": "2018-04-19T14:00:41Z",
       "completed_at": "2020-09-30T00:00:00Z",
       "updated_at": "2020-09-30T00:00:00Z",
       "status": "Completed",
@@ -317,9 +357,12 @@ curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1/lessons/:lesson_id/
       "id": 2,
       "resource_type": "assignment",
       "assignee_id": 2,
+      "assignable_type": "Lesson",
+      "assignable_id": 15,
       "ext_uid": "DEF456",
       "due_by": "2020-09-30T00:00:00Z",
       "reassigned_at": "2020-09-30T00:00:00Z",
+      "started_at": "2018-04-19T14:00:41Z",
       "completed_at": null,
       "updated_at": "2020-09-30T00:00:00Z",
       "status": "Incomplete",
@@ -341,6 +384,10 @@ Parameter | Required | Type |  Description
 lesson_id | yes | Positive Integer | The lesson to access.  The company must have access to the lesson.
 <%= pagination_query_params.chomp %>
 
+<aside class="notice">
+  Lesson assignments are only counted when that particular lesson is assigned. If a lesson is contained in a path and the path is assigned, the lesson is not counted as assigned.
+</aside>
+
 ## Lesson Completed Assignments (v1.1)
 
 ```shell
@@ -361,6 +408,10 @@ This endpoint retrieves the number of completed assignments for a given lesson.
 ### HTTP Request
 
 `GET https://api.lessonly.com/api/v1.1/lessons/:lesson_id/assignments/completed`
+
+<aside class="notice">
+  We only count a lesson as assigned if the individual lesson was assigned. We do not count a lesson as assigned if it was part of a path.
+</aside>
 
 ## Assign Lesson
 

--- a/source/includes/_paths.md.erb
+++ b/source/includes/_paths.md.erb
@@ -13,47 +13,16 @@ curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1/paths"
   "type": "paths",
   "paths": [
     {
-      "id": 1,
-      "title": "Path 1",
-      "archived_at": null,
-      "archived_by_user_id": null,
-      "public": false,
-      "created_at": "2017-07-24T10:47:23Z",
-      "last_updated_at": "2017-07-24T10:49:10Z",
-      "published_at": null,
-      "publisher_id": null,
-      "tags": [
-        {
-          "id": 1,
-          "resource_type": "tag",
-          "name": "Engineering"
-        }
-      ],
-      "links": {
-        "overview": "https://mycompany.lessonly.com/paths/1-path-1"
-      }
+        "id": 271,
+        "title": "Sales Onboarding",
+        "archived_at": "2018-02-28T08:53:40.614-05:00",
+        "archived_by_user_id": 78
     },
     {
-      "id": 2,
-      "title": "Path 2",
-      "archived_at": "2017-06-28T10:46:03.467-04:00",
-      "archived_by_user_id": 123,
-      "public": true,
-      "created_at": "2017-07-24T10:47:23Z",
-      "last_updated_at": "2017-07-24T10:49:10Z",
-      "published_at": "2017-08-21T11:16:22Z",
-      "publisher_id": 1234,
-      "tags": [
-        {
-          "id": 1,
-          "resource_type": "tag",
-          "name": "Engineering"
-        }
-      ],
-      "links": {
-        "shareable": "https://mycompany.lessonly.com/path/2-path-2",
-        "overview": "https://mycompany.lessonly.com/paths/2-path-2"
-      }
+        "id": 33,
+        "title": "Moderation Team Onboarding - August",
+        "archived_at": "2017-08-18T15:26:12.786-04:00",
+        "archived_by_user_id": 13018
     }
   ]
 }
@@ -64,6 +33,52 @@ This endpoint retrieves all paths.
 ### HTTP Request
 
 `GET https://api.lessonly.com/api/v1/paths`
+
+## List Paths (v1.1)
+
+```shell
+curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1/paths"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "type": "paths",
+  "paths": [
+    {
+        "resource_type": "path",
+        "id": 31,
+        "title": "Competition",
+        "archived_at": null,
+        "archived_by_user_id": null,
+        "public": true,
+        "created_at": "2017-08-17T13:09:35Z",
+        "last_updated_at": "2018-02-02T12:52:53Z",
+        "published_at": "2017-08-17T18:54:22.870-04:00",
+        "publisher_id": 668968,
+        "tags": [
+            {
+                "id": 3,
+                "resource_type": "tag",
+                "name": "Sales"
+            }
+        ],
+        "links": {
+            "shareable": "https://dev.lessonly.com/path/31-competition",
+            "overview": "https://dev.lessonly.com/paths/31-competition"
+        }
+    }
+  ]
+}
+```
+
+This endpoint retrieves all paths
+
+### HTTP Request
+
+`GET https://api.lessonly.com/api/v1.1/paths`
+
 
 ## Show Path Details
 
@@ -409,6 +424,7 @@ curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1/paths/:path_id/assi
       "assignee_id": 2,
       "assignable_type": "LearningPaths::Path",
       "assignable_id": 1,
+      "score": 80,
       "ext_uid": "ABC123",
       "due_by": "2020-09-30T00:00:00Z",
       "assigned_at": "2020-03-20T00:00:00Z",
@@ -424,6 +440,7 @@ curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1/paths/:path_id/assi
       "assignee_id": 3,
       "assignable_type": "LearningPaths::Path",
       "assignable_id": 1,
+      "score": null,
       "ext_uid": "DEF456",
       "due_by": "2020-09-30T00:00:00Z",
       "reassigned_at": "2020-09-30T00:00:00Z",

--- a/source/includes/_paths.md.erb
+++ b/source/includes/_paths.md.erb
@@ -37,7 +37,7 @@ This endpoint retrieves all paths.
 ## List Paths (v1.1)
 
 ```shell
-curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1/paths"
+curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1.1/paths"
 ```
 
 > The above command returns JSON structured like this:

--- a/source/includes/_tags.md
+++ b/source/includes/_tags.md
@@ -73,22 +73,29 @@ curl -u "SUBDOMAIN:API_KEY" "https://api.lessonly.com/api/v1/tags/:tag_id/lesson
   "type": "tag_lessons",
   "lessons": [
     {
-      "id": 5,
-      "resource_type": "lesson",
-      "title": "Marketing 101",
-      "assignees_count": 21,
-      "completed_count": 1,
-      "retake_score": 90,
-      "description": "A quick overview about how we do marketing."
-    },
-    {
-      "id": 456,
-      "resource_type": "lesson",
-      "title": "Development 101",
-      "assignees_count": 11,
-      "completed_count": 5,
-      "retake_score": 95,
-      "description": "A quick overview about how we do development."
+        "id": 19458,
+        "resource_type": "lesson",
+        "title": "Industry Update 10/16/15",
+        "assignees_count": 1,
+        "completed_count": 0,
+        "retake_score": 80,
+        "description": "A quick overview about how we do marketing.",
+        "public": true,
+        "created_at": "2015-10-15T23:22:31Z",
+        "last_updated_at": null,
+        "archived_at": "2016-09-07T12:19:55.453-04:00",
+        "archived_by_user_id": 651540,
+        "tags": [
+            {
+                "id": 18448,
+                "resource_type": "tag",
+                "name": "Archive"
+            }
+        ],
+        "links": {
+            "shareable": "https://adidas.lessonly.com/lesson/19458-industry-update-10-16-15",
+            "overview": "https://adidas.lessonly.com/lessons/19458-industry-update-10-16-15"
+        }
     }
   ]
 }

--- a/source/includes/_users.md.erb
+++ b/source/includes/_users.md.erb
@@ -10,61 +10,46 @@
 
 ```json
 {
-  "type": "users",
-  "resource_type": "user",
-  "total_users": 2000,
-  "page": 1,
-  "per_page": 2,
-  "total_pages": 1000,
-  "users":[
-      {
-        "id": 1,
-        "name": "User Name",
-        "email": "email1@example.com",
-        "role": "learner",
-        "ext_uid": "ABC123",
-        "archived_at": null,
-        "archived_by_user_id": null,
-        "job_title": "Account Executive",
-        "business_unit": "Global",
-        "department": "Sales",
-        "location": "Illinois",
-        "locale": "en",
-        "hire_date": "2014-12-25",
-        "manager_name": "Mary Doe",
-        "custom_user_field_data": [
-          {
-            "id": 1,
-            "custom_user_field_id": 1,
-            "name": "Custom Field Name 1",
-            "value": "Custom Value 1"
-          }
-        ]
-      },
-      {
-        "id": 2,
-        "name": "User Name",
-        "email": "email2@example.com",
-        "role": "learner",
-        "ext_uid": "DEF456",
-        "archived_at": null,
-        "archived_by_user_id": null,
-        "job_title": "Engineer",
-        "business_unit": "Global",
-        "department": "IT",
-        "location": "California",
-        "locale": "en",
-        "hire_date": "2014-12-25",
-        "manager_name": "Jane Doe",
-        "custom_user_field_data": [
-          {
-            "id": 2,
-            "custom_user_field_id": 1,
-            "name": "Custom Field Name 1",
-            "value": "Custom Value 2"
-          }
-        ]
-      }
+    "type": "users",
+    "total_users": 300,
+    "total_pages": 150,
+    "page": 1,
+    "per_page": 2,
+    "users": [
+        {
+            "id": 78,
+            "resource_type": "user",
+            "ext_uid": "5745365608",
+            "email": "joe@lessonly.com",
+            "name": "Joe Ubuntu",
+            "role": "admin",
+            "archived_at": null,
+            "archived_by_user_id": null,
+            "job_title": "",
+            "business_unit": "",
+            "department": "",
+            "location": "",
+            "locale": "en",
+            "hire_date": null,
+            "manager_name": ""
+        },
+        {
+            "id": 1694,
+            "resource_type": "user",
+            "ext_uid": null,
+            "email": "alexie@lessonly.com",
+            "name": "James alexie",
+            "role": "admin",
+            "archived_at": "2019-02-01T02:51:40.436-05:00",
+            "archived_by_user_id": 1640090,
+            "job_title": null,
+            "business_unit": null,
+            "department": null,
+            "location": null,
+            "locale": "en",
+            "hire_date": null,
+            "manager_name": null
+        }
     ]
 }
 ```
@@ -81,6 +66,88 @@ Parameter | Required | Type | Description
 --------- | ------- | ------- | -----------
 <%= pagination_query_params.chomp %>
 filter | no | String | Specified user filter for users list. Supported filters are email, ext_uid, sso_id, and custom_user_field. The SSO ID is the provider ID that we store from a successful SSO request. The format for custom_user_field is `filter[custom_user_field][FIELD_ID]=FIELD_VALUE`.
+
+## List Users (v1.1)
+
+```shell
+<%= api_get_request('/users', 'v1.1') %>
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+    "type": "users",
+    "total_users": 300,
+    "total_pages": 150,
+    "page": 1,
+    "per_page": 2,
+    "users": [
+        {
+            "id": 78,
+            "resource_type": "user",
+            "ext_uid": "5745365608",
+            "email": "max@lessonly.com",
+            "name": "Max Yoder",
+            "role": "admin",
+            "archived_at": null,
+            "archived_by_user_id": null,
+            "job_title": "",
+            "business_unit": "",
+            "department": "",
+            "location": "",
+            "locale": "en",
+            "hire_date": null,
+            "manager_name": "",
+            "mobile_phone_number": null,
+            "custom_user_field_data": [
+                {
+                    "id": 1823576,
+                    "custom_user_field_id": 2096,
+                    "value": "5745365608",
+                    "name": "SMS Reminder Phone Number"
+                },
+            ],
+            "groups": {
+                "member": [
+                    {
+                        "id": 38780,
+                        "name": "Corteva Mobile Test Group"
+                    },
+                    {
+                        "id": 15251,
+                        "name": "Leadership: Execs, Directors & Managers"
+                    }
+                ],
+                "manager": [
+                    {
+                        "id": 46421,
+                        "name": "Org - AE - West"
+                    },
+                    {
+                        "id": 46407,
+                        "name": "Org - Customer Support"
+                    },
+                ]
+            }
+        }
+    ]
+}
+```
+
+This endpoint retrieves all users.
+
+### HTTP Request
+
+`GET https://api.lessonly.com/api/v1.1/users?filter[email]=email@example.com`
+
+### Query Parameters
+
+Parameter | Required | Type | Description
+--------- | ------- | ------- | -----------
+<%= pagination_query_params.chomp %>
+filter | no | String | Specified user filter for users list. Supported filters are email, ext_uid, sso_id, and custom_user_field. The SSO ID is the provider ID that we store from a successful SSO request. The format for custom_user_field is `filter[custom_user_field][FIELD_ID]=FIELD_VALUE`.
+
 
 ## Show User Details
 


### PR DESCRIPTION
## Why

Resolves [[ch26315]](https://app.clubhouse.io/lessonly/story/26315/correcting-api-documentation)

## What

- Added v1.1 endpoint for listing lessons
- Added v1.1 endpoint for listing users
- Resolved discrepancies on assignments, lessons, tags, paths and groups json response

## Testing Notes

- Check out to this branch
- Run `bundle exec middleman`
- Preview the changes at http://localhost:4567

## Merge Instructions

Post-merge, we'll need to push these changes live with `bundle exec rake publish`