### PR TITLE
Fix Typo in _errors.md

### DIFF
--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -6,7 +6,7 @@ Error Code | Meaning
 ---------- | -------
 400 | Malformed Request -- Verify that the parameters required are being passed in and all parameters have the format specified in the documentation.  
 401 | Unauthorized -- Verify that you have passed your company's domain and API key correctly.
-403 | Forbidden -- The endpoint that you have tried to access you do not have privaleges to.
+403 | Forbidden -- The endpoint that you have tried to access you do not have privileges to.
 404 | Not Found -- The resource in the endpoint could not be found.  Verify the resource id.
 405 | Method Not Allowed -- You tried to access an endpoint with an invalid method
 406 | Not Acceptable -- You requested a format that isn't json


### PR DESCRIPTION
## Why?

Because there is a word spelled incorrectly, and we want to make sure things are as tidy as possible.

## What?

The word "privileges" under the Errors section, for a 403 error.

## Testing Notes & Steps

Confirming that I, too, didn't spell privileges incorrectly. I looked it up to be sure, it's a tricky one.