### PR TITLE
Change 'domain' to 'subdomain' in API docs

### DIFF
--- a/source/includes/_authentication.md
+++ b/source/includes/_authentication.md
@@ -8,11 +8,11 @@ curl -u "SUBDOMAIN:API_KEY" "api_endpoint_here"
 
 ```
 
-> Make sure to replace `SUBDOMAIN` with your Lessonly domain and `API_KEY` with your personal API key.
+> Make sure to replace `SUBDOMAIN` with your Lessonly subdomain and `API_KEY` with your personal API key.
 
 Lessonly uses API keys and basic HTTP authorization to allow access to the API. All API requests must be sent over HTTPS. You can register a new Lessonly API key by signing into Lessonly and navigating to the settings page.  If you do not see the API key link, you may need to request for the feature to be activated:  [here] (mailto:info@lessonly.com).
 
 
 <aside class="alert">
-You must replace <code>SUBDOMAIN</code> with your Lessonly domain and <code>API_KEY</code> with your personal API key.
+You must replace <code>SUBDOMAIN</code> with your Lessonly subdomain and <code>API_KEY</code> with your personal API key.
 </aside>

--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -5,7 +5,7 @@ The Lessonly API uses the following error codes:
 Error Code | Meaning
 ---------- | -------
 400 | Malformed Request -- Verify that the parameters required are being passed in and all parameters have the format specified in the documentation.  
-401 | Unauthorized -- Verify that you have passed your company's domain and API key correctly.
+401 | Unauthorized -- Verify that you have passed your company's subdomain and API key correctly.
 403 | Forbidden -- The endpoint that you have tried to access you do not have privileges to.
 404 | Not Found -- The resource in the endpoint could not be found.  Verify the resource id.
 405 | Method Not Allowed -- You tried to access an endpoint with an invalid method


### PR DESCRIPTION
[ch12278]

## Why?

We have had multiple customers get confused by what should be the "user name" when authenticating the API. The latest customer was a custom domain client and was really confused. We need to update the docs to make it clear that we need them to use the subdomain that is setup for Lessonly (before a custom domain change)

## What?

Simple text replace in only two different areas of the API documentation.

## Testing Steps

- Check for the word 'domain' to be changed to 'subdomain' in the files `_authentication.md` and `errors.md`
- Check for any overlooked instances of the word 'domain' in the docs that would need to be replaced