### PR TITLE
Add documentation on lesson-level completion status for path assignments

### DIFF
--- a/source/includes/_assignments.md.erb
+++ b/source/includes/_assignments.md.erb
@@ -40,6 +40,7 @@
       "assignable_type": "LearningPaths::Path",
       "assignable_id": 1,
       "ext_uid": "DEF456",
+      "assigned_at": "2016-02-22T17:35:17Z",
       "due_by": "2020-09-30T00:00:00Z",
       "reassigned_at": "2020-09-30T00:00:00Z",
       "status": "Incomplete",
@@ -51,10 +52,11 @@
       "id": 3,
       "resource_type": "assignment",
       "assignee_id": 3,
-      "score": 100,
+      "score": null,
       "assignable_type": "LearningPaths::Path",
       "assignable_id": 1,
       "ext_uid": "DEF456",
+      "assigned_at": "2016-02-22T17:35:17Z",
       "due_by": "2016-03-27T14:15:17Z",
       "reassigned_at": "2020-09-30T00:00:00Z",
       "status": "Overdue",
@@ -66,10 +68,11 @@
       "id": 4,
       "resource_type": "assignment",
       "assignee_id": 4,
-      "score": 80,
+      "score": null,
       "assignable_type": "LearningPaths::Path",
       "assignable_id": 1,
       "ext_uid": "DEF456",
+      "assigned_at": "2016-02-22T17:35:17Z",
       "due_by": "2020-09-30T00:00:00Z",
       "reassigned_at": "2020-09-30T00:00:00Z",
       "status": "Grade Pending",
@@ -88,6 +91,176 @@ To view assignments for a particular [user](#user-assignments), [lesson](#lesson
 ### HTTP Request
 
 `GET https://api.lessonly.com/api/v1/assignments`
+
+### Query Parameters
+
+Parameter | Required | Type | Description
+--------- | ------- | ------- | -----------
+<%= pagination_query_params.chomp %>
+gt | no | String | Specified greater than filter for assignments list.  Supported filters are (updated_at). Please follow ISO8601 date format.
+
+## List Assignments (v1.1)
+
+```shell
+<%= api_get_request('/assignments', 'v1.1') %>
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "type": "assignments",
+  "total_assignments": 2000,
+  "page": 1,
+  "per_page": 2,
+  "total_pages": 1000,
+  "assignments":[
+    {
+      "id": 1,
+      "resource_type": "assignment",
+      "assignee_id": 1,
+      "score": 90,
+      "assignable_type": "Lesson",
+      "assignable_id": 1,
+      "ext_uid": "ABC123",
+      "assigned_at": "2016-02-22T17:35:17Z",
+      "due_by": "2020-09-30T00:00:00Z",
+      "reassigned_at": "2016-03-22T17:35:17Z",
+      "status": "Completed",
+      "started_at": "2016-03-28T14:15:17Z",
+      "completed_at": "2016-03-28T18:20:06Z",
+      "updated_at": "2016-03-28T18:20:06Z"
+    },
+    {
+      "id": 2,
+      "resource_type": "assignment",
+      "assignee_id": 2,
+      "score": null,
+      "assignable_type": "LearningPaths::Path",
+      "assignable_id": 1,
+      "ext_uid": "DEF456",
+      "assigned_at": "2016-02-22T17:35:17Z",
+      "due_by": "2020-09-30T00:00:00Z",
+      "reassigned_at": "2016-03-28T10:25:17Z",
+      "status": "Incomplete",
+      "started_at": "2016-03-28T14:15:17Z",
+      "completed_at": null,
+      "updated_at": "2016-03-28T18:20:06Z",
+      "contents": [
+        {
+          "id": 2,
+          "resource_type": "lesson",
+          "started_at": null,
+          "completed_at": null,
+          "status": "Incomplete"
+        },
+        {
+          "id": 4,
+          "resource_type": "path",
+          "contents": [
+            {
+              "id": 3,
+              "resource_type": "lesson",
+              "started_at": "2019-01-18T09:48:10Z",
+              "completed_at": "2019-01-18T14:43:33Z",
+              "status": "Completed"
+            },
+            {
+              "id": 5,
+              "resource_type": "path",
+              "contents": [
+                {
+                  "id": 4,
+                  "resource_type": "lesson",
+                  "started_at": "2019-01-18T09:48:10Z",
+                  "completed_at": "2019-01-18T14:43:33Z",
+                  "status": "Completed"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "resource_type": "assignment",
+      "assignee_id": 3,
+      "score": 100,
+      "assignable_type": "LearningPaths::Path",
+      "assignable_id": 1,
+      "ext_uid": "DEF456",
+      "assigned_at": "2016-02-22T17:35:17Z",
+      "due_by": "2016-03-27T14:15:17Z",
+      "reassigned_at": "2016-03-20T14:15:17Z",
+      "status": "Completed",
+      "started_at": "2016-03-28T14:15:17Z",
+      "completed_at": "2016-03-30T18:20:06Z",
+      "updated_at": "2016-03-28T18:20:06Z",
+      "contents": [
+        {
+          "id": 2,
+          "resource_type": "lesson",
+          "started_at": "2016-03-28T14:15:17Z",
+          "completed_at": "2016-03-30T18:20:06Z",
+          "status": "Completed"
+        },
+      ]
+    },
+    {
+      "id": 4,
+      "resource_type": "assignment",
+      "assignee_id": 3,
+      "score": null,
+      "assignable_type": "Lesson",
+      "assignable_id": 1,
+      "ext_uid": "DEF456",
+      "assigned_at": "2016-02-22T17:35:17Z",
+      "due_by": "2016-03-27T14:15:17Z",
+      "reassigned_at": null,
+      "status": "Overdue",
+      "started_at": "2016-03-28T14:15:17Z",
+      "completed_at": null,
+      "updated_at": "2016-03-28T18:20:06Z"
+    },
+    {
+      "id": 5,
+      "resource_type": "assignment",
+      "assignee_id": 4,
+      "score": null,
+      "assignable_type": "LearningPaths::Path",
+      "assignable_id": 1,
+      "ext_uid": "DEF456",
+      "assigned_at": "2016-02-22T17:35:17Z",
+      "due_by": "2016-03-27T14:15:17Z",
+      "reassigned_at": "2016-03-23T16:43:17Z",
+      "status": "Grade Pending",
+      "started_at": "2016-03-28T14:15:17Z",
+      "completed_at": "2016-03-30T18:20:06Z",
+      "updated_at": "2016-03-28T18:20:06Z",
+      "contents": [
+        {
+          "id": 2,
+          "resource_type": "lesson",
+          "started_at": "2016-03-28T14:15:17Z",
+          "completed_at": null,
+          "status": "Incomplete"
+        },
+      ]
+    }
+  ]
+}
+```
+
+This endpoint returns paginated assignments in no particular order across all of your users, lessons, and paths. Optionally, you can filter by assignments with activity after a given ISO8601 timestamp by passing `gt[updated_at]=TIMESTAMP` in the query string.
+
+Path assignments show completion status (Completed/Incomplete) for lessons in the path.
+
+To view assignments for a particular [user](#user-assignments), [lesson](#lesson-assignments), or [path](#path-assignments) please use those dedicated endpoints.
+
+### HTTP Request
+
+`GET https://api.lessonly.com/api/v1.1/assignments`
 
 ### Query Parameters
 


### PR DESCRIPTION
## Why

Resolves [[ch28015]](https://app.clubhouse.io/lessonly/story/28015)

To improve our SF integration, we changed our endpoint `GET /api/v1.1/assignments` to reflect lesson-level status (complete/incomplete) inside a path. However, we have not communicated this change via our API documentation. This is not only inaccurate but leading to missed opportunities for our clients to better leverage our data.


## What

- Add documentation on Assignment List v1.1 endpoint which adds lesson-level completion status for path assignments

## Testing Notes

- [x] Pull this branch locally
- [x] Install dependencies from the terminal `bundle install`
- [x] Start the server `bundle exec middleman`
- [x] Preview the changes at http://localhost:4567/#list-assignments-v1-1

## Merge Instructions

Post-merge, we'll need to push these changes live with `bundle exec rake publish`