### PR TITLE
Update API Documentation Create User notify [ch28987]

### DIFF
--- a/source/includes/_users.md.erb
+++ b/source/includes/_users.md.erb
@@ -317,7 +317,7 @@ location | no | String | User location
 locale | no | String | User locale code to control the interface language. Options: ar, de, en, es, fr, it, ja, nl, pt, ru, sv, zh-CN. Defaults to 'en'.
 hire_date | no | String | User hire date. Must be an ISO8601 formatted date (YYYY-MM-DD).
 manager_name | no | String | User manager name
-notify | no | String | Whether or not to notify the user.  Passing 'false' will not send an email notification to the user that their account has been created. Defaults to 'true'.
+notify | no | String | Whether or not to notify the user.  Passing 'false' will not send an email notification to the user that their account has been created. Defaults to 'true' for admin, manager, creator and custom roles. Defaults to 'false' for learner role.
 custom_user_fields |  no | Array | Custom user fields for the user. Hashes must contain a "value" and either a "customer_user_field_id" or "name". If an unknown custom user field "name" is provided, a new custom user field will be created with that name.
 
 ## Update User


### PR DESCRIPTION
## Why?

Resolves [[ch28987]](https://app.clubhouse.io/lessonly/story/28987/update-api-documentation-create-user-notify-parameter-should-show-default-false-for-learner-true-for-other-roles)

API docs for creating users where not reflect the current create user model. When creating a user with the role learner notify will default to false. 

## What?

Our API docs now reflect this fact and will help prevent users from leaving off the notify param when calling create learners if they would like users notified.


### Feature testing steps:

- [ ] Clone lessonly-api-repo (git clone git@github.com:lessonly/lessonly-api-docs.git)
- [ ] In directory run bundle exec middleman
- [ ] open http://localhost:4567/#create-user
- [ ] Proof and review the new notfiy param language 
   `Whether or not to notify the user. Passing ‘false’ will not send an email notification to the user that their account has been created. Defaults to ‘true’ for admin, manager, creator and custom roles. Defaults to ‘false’ for learner role.`


### To deploy
 use `rake publish` after the merge.

